### PR TITLE
Add a new dbus interface to trigger NMI.

### DIFF
--- a/xyz/openbmc_project/Control/Host/NMI.interface.yaml
+++ b/xyz/openbmc_project/Control/Host/NMI.interface.yaml
@@ -1,0 +1,13 @@
+description: >
+    It is a non-maskable interrupt or signal for triggering dumps from the host
+    operating system when host is unresponsive or hung.
+
+methods:
+    - name: NMI
+      description: >
+         Generic method to initiate non maskable interrupt on all
+         host processors.
+      errors:
+        - xyz.openbmc_project.Common.Error.InternalFailure
+
+


### PR DESCRIPTION
https://gerrit.openbmc-project.xyz/#/c/openbmc/phosphor-dbus-interfaces/+/21770/
Add a new dbus interface to trigger NMI.

Signed-off-by: Lakshminarayana R. Kammath <lkammath@in.ibm.com>
Change-Id: I81f61fbbba757bff2d99585ca0e22816483c7c37