### PR TITLE
Add Blackout error to OP940

### DIFF
--- a/xyz/openbmc_project/State/Shutdown/Power.errors.yaml
+++ b/xyz/openbmc_project/State/Shutdown/Power.errors.yaml
@@ -1,2 +1,5 @@
 - name: Fault
   description: The system was shut down because a power fault was detected.
+
+- name: Blackout
+  description: The system suffered a power blackout.


### PR DESCRIPTION
Already in master.  Needed by code in phosphor-state-manager.