### PR TITLE
Adding Invalid Argument Error for Nameservers property

### DIFF
--- a/xyz/openbmc_project/Network/EthernetInterface.interface.yaml
+++ b/xyz/openbmc_project/Network/EthernetInterface.interface.yaml
@@ -30,6 +30,8 @@ properties:
       type: array[string]
       description: >
           DNS servers on the interface.
+      errors:
+          - xyz.openbmc_project.Common.Error.InvalidArgument
     - name: NTPServers
       type: array[string]
       description: >


### PR DESCRIPTION
The validation for Nameservers property was added a part of
below commit.

https://gerrit.openbmc-project.xyz/#/c/openbmc/phosphor-networkd/+/24601/

The idea behind this commit is to support the Validation failure,
where we catch the InvalidArgument error, so that Network service
wont be crashed.

TestedBy:

PATCH operation on Nameservers property using some random junk values
and made sure that , the backend throws an error without the Network
service being crashed.

Signed-off-by: Manojkiran Eda <manojkiran.eda@gmail.com>
Change-Id: I4233a1ea69714825da51bc9def13d79047f1f02d