### PR TITLE
Network: add fallback option for LinkLocalAddressing property

### DIFF
--- a/xyz/openbmc_project/Network/EthernetInterface.interface.yaml
+++ b/xyz/openbmc_project/Network/EthernetInterface.interface.yaml
@@ -50,6 +50,7 @@ enumerations:
       description: >
           Possible link local auto configuration values.
       values:
+        - name: fallback
         - name: both
         - name: v4
         - name: v6


### PR DESCRIPTION
Systemd.network allows fallback option for LinkLocalAddressing
If "fallback" or "ipv4-fallback" is specified, then an IPv4
link-local address is configured only when DHCPv4 fails.
If "fallback", an IPv6 link-local address is always configured.

Signed-off-by: Ravi Teja <raviteja28031990@gmail.com>
Change-Id: I2bff8ae4f147426210752eeddbe85a54d69b3c8e