### PR TITLE
Revert linklocal fallback option

### DIFF
--- a/xyz/openbmc_project/Network/EthernetInterface.interface.yaml
+++ b/xyz/openbmc_project/Network/EthernetInterface.interface.yaml
@@ -50,7 +50,6 @@ enumerations:
       description: >
           Possible link local auto configuration values.
       values:
-        - name: fallback
         - name: both
         - name: v4
         - name: v6


### PR DESCRIPTION
Linklocal fallback is not working in op940, so reverting fallback option changes