### PR TITLE
Collect fru vpd

### DIFF
--- a/gen/com/ibm/Dump/Entry/Hardware/meson.build
+++ b/gen/com/ibm/Dump/Entry/Hardware/meson.build
@@ -1,0 +1,14 @@
+# Generated file; do not modify.
+generated_sources += custom_target(
+    'com/ibm/Dump/Entry/Hardware__cpp'.underscorify(),
+    input: [ '../../../../../../yaml/com/ibm/Dump/Entry/Hardware.interface.yaml',  ],
+    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'cpp',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../../yaml',
+        'com/ibm/Dump/Entry/Hardware',
+    ],
+)
+

--- a/gen/com/ibm/Dump/Entry/meson.build
+++ b/gen/com/ibm/Dump/Entry/meson.build
@@ -1,4 +1,18 @@
 # Generated file; do not modify.
+subdir('Hardware')
+generated_others += custom_target(
+    'com/ibm/Dump/Entry/Hardware__markdown'.underscorify(),
+    input: [ '../../../../../yaml/com/ibm/Dump/Entry/Hardware.interface.yaml',  ],
+    output: [ 'Hardware.md' ],
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'markdown',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../yaml',
+        'com/ibm/Dump/Entry/Hardware',
+    ],
+)
+
 subdir('Hostboot')
 generated_others += custom_target(
     'com/ibm/Dump/Entry/Hostboot__markdown'.underscorify(),

--- a/gen/com/ibm/Host/Target/meson.build
+++ b/gen/com/ibm/Host/Target/meson.build
@@ -1,0 +1,14 @@
+# Generated file; do not modify.
+generated_sources += custom_target(
+    'com/ibm/Host/Target__cpp'.underscorify(),
+    input: ['../../../../../yaml/com/ibm/Host/Target.interface.yaml',  ],
+    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'cpp',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../yaml',
+        'com/ibm/Host/Target',
+    ],
+)
+

--- a/gen/com/ibm/Host/meson.build
+++ b/gen/com/ibm/Host/meson.build
@@ -1,0 +1,16 @@
+# Generated file; do not modify.
+subdir('Target')
+generated_others += custom_target(
+    'com/ibm/Host/Target__markdown'.underscorify(),
+    input: [ '../../../../yaml/com/ibm/Host/Target.interface.yaml',  ],
+    output: [ 'Target.md' ],
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'markdown',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../yaml',
+        'com/ibm/Host/Target',
+    ],
+    build_by_default: true,
+)
+

--- a/gen/com/ibm/meson.build
+++ b/gen/com/ibm/meson.build
@@ -2,6 +2,7 @@
 subdir('Dump')
 subdir('Logging')
 subdir('VPD')
+subdir('Host')
 generated_others += custom_target(
     'com/ibm/VPD__markdown'.underscorify(),
     input: [ '../../../yaml/com/ibm/VPD.errors.yaml',  ],

--- a/yaml/com/ibm/Dump/Create.interface.yaml
+++ b/yaml/com/ibm/Dump/Create.interface.yaml
@@ -21,7 +21,7 @@ enumerations:
         - name: 'ErrorLogId'
           description: >
               The id of the log associated with action which triggered the
-              dump.
+              dump. The value should be a 32 bit unsigned integer.
         - name: 'DumpType'
           description: >
               Type of the dump to be collected

--- a/yaml/com/ibm/Dump/Create.interface.yaml
+++ b/yaml/com/ibm/Dump/Create.interface.yaml
@@ -25,6 +25,10 @@ enumerations:
         - name: 'DumpType'
           description: >
               Type of the dump to be collected
+        - name: 'FailingUnitId'
+          description: >
+              A unique id of failing hardware unit which is causing the dump.
+              The value should be a 32 bit unsigned integer.
 
     - name: DumpType
       description: >
@@ -34,3 +38,6 @@ enumerations:
           description: >
               Hostboot dump is collected during a boot failure during the
               hostboot booting phase.
+        - name: 'Hardware'
+          desription: >
+              Hardware dump is collected during a system checkstop.

--- a/yaml/com/ibm/Dump/Entry/Hardware.interface.yaml
+++ b/yaml/com/ibm/Dump/Entry/Hardware.interface.yaml
@@ -1,0 +1,7 @@
+description: >
+    Implement this to add Hardware dump management.
+
+    Hardware dump is a collection hardware state information,
+    including various registers, and it is used for debugging
+    system checkstop. checkstop is the descriptive term for
+    entire system termination by the hardware due to a detected error.

--- a/yaml/com/ibm/Host/Target.interface.yaml
+++ b/yaml/com/ibm/Host/Target.interface.yaml
@@ -1,0 +1,25 @@
+description: >
+        Implement to choose the hypervisor.
+        This property reflects the user settings and not a status.
+        It is possible that the user can change the setting
+        at any point of time. But the property will be applied
+        only when the host boots the next time.
+
+properties:
+        - name: Target
+          type: enum[ self.Hypervisor ]
+          default: PowerVM
+          description:
+                The desired hypervisor.
+
+enumerations:
+        - name: Hypervisor
+          description: >
+                Possible hypervisors.
+          values:
+            - name: PowerVM
+              description: >
+                PowerVM as the hypervisor.
+            - name: OPAL
+              description: >
+                OPAL as the hypervisor.

--- a/yaml/xyz/openbmc_project/Dump/Create.interface.yaml
+++ b/yaml/xyz/openbmc_project/Dump/Create.interface.yaml
@@ -16,12 +16,13 @@ methods:
           Method to create a manual Dump.
       parameters:
         - name: AdditionalData
-          type: dict[string, string]
+          type: dict[string, variant[string,uint64]]
           description: >
             The additional data, if any, for initiating the dump.
             The key in this case should be an implementation
             specific enum defined for the specific type of dump
             either in xyz or in a domain.
+            The values can be either a string or a 64 bit number.
             The enum-format string is required to come from a
             parallel class with this specific Enum name.
             All of the Enum strings should be in the format

--- a/yaml/xyz/openbmc_project/Inventory/Item/Chassis.interface.yaml
+++ b/yaml/xyz/openbmc_project/Inventory/Item/Chassis.interface.yaml
@@ -3,40 +3,6 @@ description: >
 
 properties:
     - name: Type
-      type: enum[self.ChassisType]
-      default: Unknown
+      type: string
       description: >
           The type of physical form factor of the chassis.
-
-enumerations:
-    - name: ChassisType
-      description: >
-          Possible chassis type
-      values:
-        - name: Component
-          description: >
-              A small chassis, card, or device that contains devices for a
-              particular subsystem or function.
-        - name: Enclosure
-          description: >
-              A generic term for a chassis that does not fit any other
-              description.
-        - name: Module
-          description: >
-              A small, typically removable, chassis or card that contains
-              devices for a particular subsystem or function.
-        - name: RackMount
-          description: >
-              A single-system chassis designed specifically for mounting in an
-              equipment rack.
-        - name: StandAlone
-          description: >
-              A single, free-standing system, commonly called a tower or
-              desktop chassis.
-        - name: Unknown
-          description: >
-              An unknown chassis type.
-        - name: Zone
-          description: >
-              A logical division or portion of a physical chassis that contains
-              multiple devices or systems that cannot be physically separated.


### PR DESCRIPTION
Interfaces required for concurrent maintenance This PR adds commits which implement interfaces to delete or collect VPD of a given FRU.
The deletion as of now just toggles the present property of that FRU on D-Bus.
Use Case:
These api's can be used for concurrent maintenance for a single given FRU.