### PR TITLE
Capacity-On-Demand: License manager DBus

### DIFF
--- a/yaml/com/ibm/License/Entry/LicenseEntry.interface.yaml
+++ b/yaml/com/ibm/License/Entry/LicenseEntry.interface.yaml
@@ -1,0 +1,32 @@
+description: >
+    Implement to represent a license which enables features on system
+    Customer installs license to unlock certain resources or features
+    Each object implements xyz.openbmc_project.License.Entry interface
+    which has LicenseName and State properties
+    and implements xyz.openbmc_project.Object.Delete interface.
+properties:
+
+    - name: LicenseName
+      type: string
+      description: >
+         Name of license 
+    - name: State
+      type: enum[self.Status]
+      default: Unknown
+      description: >
+          The current state of the license.
+enumerations:
+    - name: Status
+      description: >
+        License status enumerations
+      values:
+        - name: Unknown
+          description: >
+            Indicates that given license state is unknown
+        - name: Enabled
+          description: >
+            Indicates that given license state is activated
+        - name: Disabled
+          description: >
+            Indicates that given license state is disabled
+

--- a/yaml/com/ibm/License/LicenseManager.interface.yaml
+++ b/yaml/com/ibm/License/LicenseManager.interface.yaml
@@ -1,0 +1,41 @@
+description: >
+      This Method accepts license key and forwards to host
+properties:
+     - name: LicenseString
+       type: string
+       description: >
+         License string of 34 characters.
+     - name: LicenseActivationStatus
+       type: enum[self.Status]
+       default: Pending
+       description: >
+         License Activation status
+enumerations:
+     - name: Status
+       description: >
+         Status enumerations
+       values:
+        - name: InvalidLicense
+          description: >
+            Indicates that given license is not valid
+        - name: Activated
+          description: >
+            Indicates that given license is activated
+        - name: Pending
+          description: >
+            Indicates that given license activation is yet to happen
+        - name: ActivationFailed
+          description: >
+            Indicates that given license activation failed due to some firmware issue
+        - name: IncorrectSystem
+          description: >
+            The license is valid, but not for the system it was installed on.
+        - name: InvalidHostState
+          description: >
+            Indicates that given license activation failed due to invalid host state
+        - name: IncorrectSequence
+          description: >
+            Indicates that given license activation failed due to invalid host state
+            The license is valid on this system, but is in the incorrect sequence.
+            (eg, was entered more than once)
+


### PR DESCRIPTION
This commit defines License Manager interface to support new license upload
and defines license entry interfaces to represent license objects

Licenses are objects representing application layer features. This is a one
to one relation ship. These objects have state and other properties to
represent each feature attributes

Signed-off-by: Sunitha Harish <sunharis@in.ibm.com>