### PR TITLE
Capacity-On-Demand: License manager DBus

### DIFF
--- a/gen/com/ibm/Host/Target/meson.build
+++ b/gen/com/ibm/Host/Target/meson.build
@@ -1,0 +1,14 @@
+# Generated file; do not modify.
+generated_sources += custom_target(
+    'com/ibm/Host/Target__cpp'.underscorify(),
+    input: ['../../../../../yaml/com/ibm/Host/Target.interface.yaml',  ],
+    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'cpp',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../yaml',
+        'com/ibm/Host/Target',
+    ],
+)
+

--- a/gen/com/ibm/Host/Target/meson.build
+++ b/gen/com/ibm/Host/Target/meson.build
@@ -1,7 +1,7 @@
 # Generated file; do not modify.
 generated_sources += custom_target(
     'com/ibm/Host/Target__cpp'.underscorify(),
-    input: ['../../../../../yaml/com/ibm/Host/Target.interface.yaml',  ],
+    input: [ '../../../../../yaml/com/ibm/Host/Target.interface.yaml',  ],
     output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/Host/meson.build
+++ b/gen/com/ibm/Host/meson.build
@@ -1,0 +1,16 @@
+# Generated file; do not modify.
+subdir('Target')
+generated_others += custom_target(
+    'com/ibm/Host/Target__markdown'.underscorify(),
+    input: [ '../../../../yaml/com/ibm/Host/Target.interface.yaml',  ],
+    output: [ 'Target.md' ],
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'markdown',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../yaml',
+        'com/ibm/Host/Target',
+    ],
+    build_by_default: true,
+)
+

--- a/gen/com/ibm/Host/meson.build
+++ b/gen/com/ibm/Host/meson.build
@@ -11,6 +11,5 @@ generated_others += custom_target(
         '--directory', meson.current_source_dir() / '../../../../yaml',
         'com/ibm/Host/Target',
     ],
-    build_by_default: true,
 )
 

--- a/gen/com/ibm/License/Entry/LicenseEntry/meson.build
+++ b/gen/com/ibm/License/Entry/LicenseEntry/meson.build
@@ -1,0 +1,14 @@
+# Generated file; do not modify.
+generated_sources += custom_target(
+    'com/ibm/License/Entry/LicenseEntry__cpp'.underscorify(),
+    input: [ '../../../../../../yaml/com/ibm/License/Entry/LicenseEntry.interface.yaml',  ],
+    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'cpp',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../../yaml',
+        'com/ibm/License/Entry/LicenseEntry',
+    ],
+)
+

--- a/gen/com/ibm/License/Entry/meson.build
+++ b/gen/com/ibm/License/Entry/meson.build
@@ -1,0 +1,15 @@
+# Generated file; do not modify.
+subdir('LicenseEntry')
+generated_others += custom_target(
+    'com/ibm/License/Entry/LicenseEntry__markdown'.underscorify(),
+    input: [ '../../../../../yaml/com/ibm/License/Entry/LicenseEntry.interface.yaml',  ],
+    output: [ 'LicenseEntry.md' ],
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'markdown',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../yaml',
+        'com/ibm/License/Entry/LicenseEntry',
+    ],
+)
+

--- a/gen/com/ibm/License/LicenseManager/meson.build
+++ b/gen/com/ibm/License/LicenseManager/meson.build
@@ -1,0 +1,14 @@
+# Generated file; do not modify.
+generated_sources += custom_target(
+    'com/ibm/License/LicenseManager__cpp'.underscorify(),
+    input: [ '../../../../../yaml/com/ibm/License/LicenseManager.interface.yaml',  ],
+    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'cpp',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../yaml',
+        'com/ibm/License/LicenseManager',
+    ],
+)
+

--- a/gen/com/ibm/License/meson.build
+++ b/gen/com/ibm/License/meson.build
@@ -1,0 +1,16 @@
+# Generated file; do not modify.
+subdir('Entry')
+subdir('LicenseManager')
+generated_others += custom_target(
+    'com/ibm/License/LicenseManager__markdown'.underscorify(),
+    input: [ '../../../../yaml/com/ibm/License/LicenseManager.interface.yaml',  ],
+    output: [ 'LicenseManager.md' ],
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'markdown',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../yaml',
+        'com/ibm/License/LicenseManager',
+    ],
+)
+

--- a/gen/com/ibm/meson.build
+++ b/gen/com/ibm/meson.build
@@ -1,6 +1,7 @@
 # Generated file; do not modify.
 subdir('Dump')
 subdir('Host')
+subdir('License')
 subdir('Logging')
 subdir('VPD')
 generated_others += custom_target(

--- a/gen/com/ibm/meson.build
+++ b/gen/com/ibm/meson.build
@@ -1,8 +1,8 @@
 # Generated file; do not modify.
 subdir('Dump')
+subdir('Host')
 subdir('Logging')
 subdir('VPD')
-subdir('Host')
 generated_others += custom_target(
     'com/ibm/VPD__markdown'.underscorify(),
     input: [ '../../../yaml/com/ibm/VPD.errors.yaml',  ],

--- a/gen/com/ibm/meson.build
+++ b/gen/com/ibm/meson.build
@@ -2,6 +2,7 @@
 subdir('Dump')
 subdir('Logging')
 subdir('VPD')
+subdir('Host')
 generated_others += custom_target(
     'com/ibm/VPD__markdown'.underscorify(),
     input: [ '../../../yaml/com/ibm/VPD.errors.yaml',  ],

--- a/gen/org/open_power/HardwareIsolation/Create/meson.build
+++ b/gen/org/open_power/HardwareIsolation/Create/meson.build
@@ -1,0 +1,14 @@
+# Generated file; do not modify.
+generated_sources += custom_target(
+    'org/open_power/HardwareIsolation/Create__cpp'.underscorify(),
+    input: [ '../../../../../yaml/org/open_power/HardwareIsolation/Create.interface.yaml',  ],
+    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'cpp',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../yaml',
+        'org/open_power/HardwareIsolation/Create',
+    ],
+)
+

--- a/gen/org/open_power/HardwareIsolation/meson.build
+++ b/gen/org/open_power/HardwareIsolation/meson.build
@@ -1,0 +1,15 @@
+# Generated file; do not modify.
+subdir('Create')
+generated_others += custom_target(
+    'org/open_power/HardwareIsolation/Create__markdown'.underscorify(),
+    input: [ '../../../../yaml/org/open_power/HardwareIsolation/Create.interface.yaml',  ],
+    output: [ 'Create.md' ],
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'markdown',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../yaml',
+        'org/open_power/HardwareIsolation/Create',
+    ],
+)
+

--- a/gen/org/open_power/meson.build
+++ b/gen/org/open_power/meson.build
@@ -1,6 +1,7 @@
 # Generated file; do not modify.
 subdir('Common')
 subdir('Control')
+subdir('HardwareIsolation')
 subdir('Host')
 generated_others += custom_target(
     'org/open_power/Host__markdown'.underscorify(),

--- a/yaml/com/ibm/Host/Target.interface.yaml
+++ b/yaml/com/ibm/Host/Target.interface.yaml
@@ -1,0 +1,25 @@
+description: >
+        Implement to choose the hypervisor.
+        This property reflects the user settings and not a status.
+        It is possible that the user can change the setting
+        at any point of time. But the property will be applied
+        only when the host boots the next time.
+
+properties:
+        - name: Target
+          type: enum[ self.Hypervisor ]
+          default: PowerVM
+          description:
+                The desired hypervisor.
+
+enumerations:
+        - name: Hypervisor
+          description: >
+                Possible hypervisors.
+          values:
+            - name: PowerVM
+              description: >
+                PowerVM as the hypervisor.
+            - name: OPAL
+              description: >
+                OPAL as the hypervisor.

--- a/yaml/com/ibm/License/Entry/LicenseEntry.interface.yaml
+++ b/yaml/com/ibm/License/Entry/LicenseEntry.interface.yaml
@@ -1,0 +1,89 @@
+description: >
+    Implement to represent a license which enables features on system
+    Customer installs license to unlock certain resources or features
+    Each object implements xyz.openbmc_project.License.Entry interface
+    which has Name and Status properties
+    and implements xyz.openbmc_project.Object.Delete interface.
+properties:
+
+    - name: Name
+      type: string
+      description: >
+         Name of license
+    - name: Status
+      type: enum[self.Status]
+      default: Unknown
+      description: >
+          The current state of the license
+    - name: Id
+      type: string
+      description: >
+         Pretty Name Invenoty.Item
+    - name: SerialNum
+      type: string
+      description: >
+         The serial number of the license
+    - name: Type
+      type: enum[self.Type]
+      default: Trial
+      description: >
+          The current type of the license
+    - name: AuthorizationType
+      type: enum[self.AuthorizationType]
+      default: Unlimited
+      description: >
+          The current Authorization type of the license
+    - name: ExpirationTime
+      type: string
+      description: >
+         The date when the license expires
+    - name: AuthDeviceNumber
+      type: uint32
+      default: 0
+      description: >
+         The number of devices authorized by the license
+    - name: Duration
+      type: string
+      description: >
+         The amount of intervening time in a time interval for license
+enumerations:
+    - name: Status
+      description: >
+        License status enumerations
+      values:
+        - name: Unknown
+          description: >
+            Indicates that given license state is unknown
+        - name: Enabled
+          description: >
+            Indicates that given license state is activated
+        - name: Disabled
+          description: >
+            Indicates that given license state is disabled
+    - name: Type
+      description: >
+        License type enumerations
+      values:
+        - name: Prototype
+          description: >
+            A prototype version of license
+        - name: Purchased
+          description: >
+            A purchased license
+        - name: Trial
+          description: >
+            A trial license
+    - name: AuthorizationType
+      description: >
+        License authorization type enumerations
+      values:
+        - name: Device
+          description: >
+            The license authorizes the feature per device
+        - name: Capacity
+          description: >
+            The license authorizes the feature to a number of devices, but not restricts to specific device
+        - name: Unlimited
+          description: >
+            The license has no limits on the device to use the feature
+

--- a/yaml/com/ibm/License/LicenseManager.interface.yaml
+++ b/yaml/com/ibm/License/LicenseManager.interface.yaml
@@ -1,0 +1,41 @@
+description: >
+      This Method accepts license key and forwards to host
+properties:
+     - name: LicenseString
+       type: string
+       description: >
+         License string of 34 characters.
+     - name: LicenseActivationStatus
+       type: enum[self.Status]
+       default: Pending
+       description: >
+         License Activation status
+enumerations:
+     - name: Status
+       description: >
+         Status enumerations
+       values:
+        - name: InvalidLicense
+          description: >
+            Indicates that given license is not valid
+        - name: Activated
+          description: >
+            Indicates that given license is activated
+        - name: Pending
+          description: >
+            Indicates that given license activation is yet to happen
+        - name: ActivationFailed
+          description: >
+            Indicates that given license activation failed due to some firmware issue
+        - name: IncorrectSystem
+          description: >
+            The license is valid, but not for the system it was installed on.
+        - name: InvalidHostState
+          description: >
+            Indicates that given license activation failed due to invalid host state
+        - name: IncorrectSequence
+          description: >
+            Indicates that given license activation failed due to invalid host state
+            The license is valid on this system, but is in the incorrect sequence.
+            (eg, was entered more than once)
+

--- a/yaml/org/open_power/HardwareIsolation/Create.interface.yaml
+++ b/yaml/org/open_power/HardwareIsolation/Create.interface.yaml
@@ -1,0 +1,40 @@
+description: >
+    This interface contains create method, which can be implemented to
+    create an xyz.openbmc_project.HardwareIsolation.Entry object
+    which will use to provide the information of isolated hardware.
+
+methods:
+    - name: CreateWithEntityPath
+      description: >
+          Create an xyz.openbmc_project.HardwareIsolation.Entry object if any
+          of hardware, need to be isolated.
+      parameters:
+        - name: EntityPath
+          type: array[byte]
+          description: >
+              The hardware entity path which is needs to isolate.
+              The hardware entity path is key between BMC OpenPOWER based
+              applications and host applications. for example,
+              "23 01 00 02 00 05 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00"
+              it representing the following hardware entity
+              "physical:sys-0/node-0/proc-0".
+        - name: Severity
+          type: enum[xyz.openbmc_project.HardwareIsolation.Entry.Type]
+          description: >
+              The severity of isolating hardware.
+        - name: BmcErrorLog
+          type: path
+          description: >
+              The BMC error log caused the isolation of hardware.
+      returns:
+        - name: Path
+          type: path
+          description: >
+              The path of created xyz.openbmc_project.HardwareIsolation.Entry
+              object.
+      errors:
+          - xyz.openbmc_project.Common.Error.InvalidArgument
+          - xyz.openbmc_project.Common.Error.TooManyResources
+          - xyz.openbmc_project.HardwareIsolation.Error.IsolatedAlready
+          - xyz.openbmc_project.Common.Error.NotAllowed
+          - xyz.openbmc_project.Common.Error.Unavailable

--- a/yaml/xyz/openbmc_project/Inventory/Item/Chassis.interface.yaml
+++ b/yaml/xyz/openbmc_project/Inventory/Item/Chassis.interface.yaml
@@ -3,43 +3,6 @@ description: >
 
 properties:
     - name: Type
-      type: enum[self.ChassisType]
-      default: Unknown
+      type: string
       description: >
           The type of physical form factor of the chassis.
-
-enumerations:
-    - name: ChassisType
-      description: >
-          Possible chassis type
-      values:
-        - name: Component
-          description: >
-              A small chassis, card, or device that contains devices for a
-              particular subsystem or function.
-        - name: Enclosure
-          description: >
-              A generic term for a chassis that does not fit any other
-              description.
-        - name: Module
-          description: >
-              A small, typically removable, chassis or card that contains
-              devices for a particular subsystem or function.
-        - name: RackMount
-          description: >
-              A single-system chassis designed specifically for mounting in an
-              equipment rack.
-        - name: StandAlone
-          description: >
-              A single, free-standing system, commonly called a tower or
-              desktop chassis.
-        - name: StorageEnclosure
-          description: >
-              A chassis that encloses storage.
-        - name: Unknown
-          description: >
-              An unknown chassis type.
-        - name: Zone
-          description: >
-              A logical division or portion of a physical chassis that contains
-              multiple devices or systems that cannot be physically separated.


### PR DESCRIPTION
This commit defines License Manager interface to support new license upload
and defines license entry interfaces to represent license objects

Licenses are objects representing application layer features. This is a one
to one relation ship. These objects have state and other properties to
represent each feature attributes

Signed-off-by: Sunitha Harish <sunharis@in.ibm.com>