### PR TITLE
Capacity-On-Demand: License manager DBus

### DIFF
--- a/gen/com/ibm/License/Entry/LicenseEntry/meson.build
+++ b/gen/com/ibm/License/Entry/LicenseEntry/meson.build
@@ -1,0 +1,14 @@
+# Generated file; do not modify.
+generated_sources += custom_target(
+    'com/ibm/License/Entry/LicenseEntry__cpp'.underscorify(),
+    input: [ '../../../../../../yaml/com/ibm/License/Entry/LicenseEntry.interface.yaml',  ],
+    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'cpp',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../../yaml',
+        'com/ibm/License/Entry/LicenseEntry',
+    ],
+)
+

--- a/gen/com/ibm/License/Entry/meson.build
+++ b/gen/com/ibm/License/Entry/meson.build
@@ -1,0 +1,15 @@
+# Generated file; do not modify.
+subdir('LicenseEntry')
+generated_others += custom_target(
+    'com/ibm/License/Entry/LicenseEntry__markdown'.underscorify(),
+    input: [ '../../../../../yaml/com/ibm/License/Entry/LicenseEntry.interface.yaml',  ],
+    output: [ 'LicenseEntry.md' ],
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'markdown',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../yaml',
+        'com/ibm/License/Entry/LicenseEntry',
+    ],
+)
+

--- a/gen/com/ibm/License/LicenseManager/meson.build
+++ b/gen/com/ibm/License/LicenseManager/meson.build
@@ -1,0 +1,14 @@
+# Generated file; do not modify.
+generated_sources += custom_target(
+    'com/ibm/License/LicenseManager__cpp'.underscorify(),
+    input: [ '../../../../../yaml/com/ibm/License/LicenseManager.interface.yaml',  ],
+    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'cpp',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../yaml',
+        'com/ibm/License/LicenseManager',
+    ],
+)
+

--- a/gen/com/ibm/License/meson.build
+++ b/gen/com/ibm/License/meson.build
@@ -1,0 +1,16 @@
+# Generated file; do not modify.
+subdir('Entry')
+subdir('LicenseManager')
+generated_others += custom_target(
+    'com/ibm/License/LicenseManager__markdown'.underscorify(),
+    input: [ '../../../../yaml/com/ibm/License/LicenseManager.interface.yaml',  ],
+    output: [ 'LicenseManager.md' ],
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'markdown',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../yaml',
+        'com/ibm/License/LicenseManager',
+    ],
+)
+

--- a/gen/com/ibm/meson.build
+++ b/gen/com/ibm/meson.build
@@ -1,6 +1,7 @@
 # Generated file; do not modify.
 subdir('Dump')
 subdir('Host')
+subdir('License')
 subdir('Logging')
 subdir('VPD')
 generated_others += custom_target(

--- a/yaml/com/ibm/License/Entry/LicenseEntry.interface.yaml
+++ b/yaml/com/ibm/License/Entry/LicenseEntry.interface.yaml
@@ -1,0 +1,64 @@
+description: >
+    Implement to represent a license which enables features on system
+    Customer installs license to unlock certain resources or features
+    Each object implements xyz.openbmc_project.License.Entry interface
+    which has Name and Status properties
+    and implements xyz.openbmc_project.Object.Delete interface.
+properties:
+
+    - name: Name
+      type: string
+      description: >
+         Name of license
+    - name: SerialNumber
+      type: string
+      description: >
+         The serial number of the license
+    - name: Type
+      type: enum[self.Type]
+      default: Trial
+      description: >
+          The current type of the license
+    - name: AuthorizationType
+      type: enum[self.AuthorizationType]
+      default: Unlimited
+      description: >
+          The current Authorization type of the license
+    - name: ExpirationTime
+      type: uint64
+      description: >
+         The time when the license expires. The time is the Epoch time,
+         number of seconds since 1 Jan 1970 00::00::00 UTC
+    - name: AuthDeviceNumber
+      type: uint32
+      default: 0
+      description: >
+         The number of devices authorized by the license
+enumerations:
+    - name: Type
+      description: >
+        License type enumerations
+      values:
+        - name: Prototype
+          description: >
+            A prototype version of license
+        - name: Purchased
+          description: >
+            A purchased license
+        - name: Trial
+          description: >
+            A trial license
+    - name: AuthorizationType
+      description: >
+        License authorization type enumerations
+      values:
+        - name: Device
+          description: >
+            The license authorizes the feature per device
+        - name: Capacity
+          description: >
+            The license authorizes the feature to a number of devices, but not restricts to specific device
+        - name: Unlimited
+          description: >
+            The license has no limits on the device to use the feature
+

--- a/yaml/com/ibm/License/LicenseManager.interface.yaml
+++ b/yaml/com/ibm/License/LicenseManager.interface.yaml
@@ -1,0 +1,41 @@
+description: >
+      This Method accepts license key and forwards to host
+properties:
+     - name: LicenseString
+       type: string
+       description: >
+         License string of 34 characters.
+     - name: LicenseActivationStatus
+       type: enum[self.Status]
+       default: Pending
+       description: >
+         License Activation status
+enumerations:
+     - name: Status
+       description: >
+         Status enumerations
+       values:
+        - name: InvalidLicense
+          description: >
+            Indicates that given license is not valid
+        - name: Activated
+          description: >
+            Indicates that given license is activated
+        - name: Pending
+          description: >
+            Indicates that given license activation is yet to happen
+        - name: ActivationFailed
+          description: >
+            Indicates that given license activation failed
+        - name: IncorrectSystem
+          description: >
+            The license is valid, but not for the system it was installed on.
+        - name: InvalidHostState
+          description: >
+            Indicates that given license activation failed due to invalid host state
+        - name: IncorrectSequence
+          description: >
+            Indicates that given license activation failed due to invalid host state
+            The license is valid on this system, but is in the incorrect sequence.
+            (eg, was entered more than once)
+

--- a/yaml/xyz/openbmc_project/State/Decorator/PowerState.interface.yaml
+++ b/yaml/xyz/openbmc_project/State/Decorator/PowerState.interface.yaml
@@ -12,10 +12,10 @@ enumerations:
     description: >
       Power state enum.
     values:
-      - name: On
+      - name: "On"
         description: >
          The state of the object is powered on.
-      - name: Off
+      - name: "Off"
         description: >
          The state of the object is powered off.
       - name: PoweringOn


### PR DESCRIPTION
This commit defines License Manager interface to support new license upload
and defines license entry interfaces to represent license objects

Licenses are objects representing application layer features. This is a one
to one relation ship. These objects have state and other properties to
represent each feature attributes

Signed-off-by: Sunitha Harish <sunharis@in.ibm.com>