### PR TITLE
ACF interface added

### DIFF
--- a/gen/xyz/openbmc_project/Certs/ACF/meson.build
+++ b/gen/xyz/openbmc_project/Certs/ACF/meson.build
@@ -1,0 +1,14 @@
+# Generated file; do not modify.
+generated_sources += custom_target(
+    'xyz/openbmc_project/Certs/ACF__cpp'.underscorify(),
+    input: [ '../../../../../yaml/xyz/openbmc_project/Certs/ACF.interface.yaml',  ],
+    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'cpp',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../yaml',
+        'xyz/openbmc_project/Certs/ACF',
+    ],
+)
+

--- a/gen/xyz/openbmc_project/Certs/meson.build
+++ b/gen/xyz/openbmc_project/Certs/meson.build
@@ -82,6 +82,20 @@ generated_others += custom_target(
     ],
 )
 
+subdir('ACF')
+generated_others += custom_target(
+    'xyz/openbmc_project/Certs/ACF__markdown'.underscorify(),
+    input: [ '../../../../yaml/xyz/openbmc_project/Certs/ACF.interface.yaml',  ],
+    output: [ 'ACF.md' ],
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'markdown',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../yaml',
+        'xyz/openbmc_project/Certs/ACF',
+    ],
+)
+
 subdir('Replace')
 generated_others += custom_target(
     'xyz/openbmc_project/Certs/Replace__markdown'.underscorify(),

--- a/yaml/xyz/openbmc_project/Certs/ACF.interface.yaml
+++ b/yaml/xyz/openbmc_project/Certs/ACF.interface.yaml
@@ -1,0 +1,40 @@
+description: >
+    ACF interface to install access control file.
+methods:
+    - name: InstallACF
+      description: >
+          Install the ACF onto the system if checks have been passed.
+      parameters:
+          - name: ACFFile
+            type: array[byte]
+            description: >
+                Binary data of ACF file
+
+      returns:
+          - name: acfInfo
+            type: struct[array[byte],boolean,string]
+            description: >
+                Returns info about acf installation.
+                acfFile contents, isACFInstalled, expirationDate of ACF
+
+      errors:
+          - xyz.openbmc_project.Common.Error.InternalFailure
+          - xyz.openbmc_project.Common.Error.NotAllowed
+          - xyz.openbmc_project.Certs.Error.InvalidCertificate
+
+    - name: GetACFInfo
+      description: >
+          Get info about ACF file
+
+      returns:
+          - name: acfInfo
+            type: struct[array[byte],boolean,string]
+            description: >
+                Returns info about acf installation.
+                acfFile contents, isACFInstalled, expirationDate of ACF
+
+      errors:
+          - xyz.openbmc_project.Common.Error.InternalFailure
+          - xyz.openbmc_project.Common.Error.NotAllowed
+          - xyz.openbmc_project.Certs.Error.InvalidCertificate
+


### PR DESCRIPTION
Methods added to interface are InstallACF and GetACFInfo
This is functionality to install an ibm-acf file onto the system
This interface is intended to be used by bmcweb.
InstallACF method is to install the ACF onto the system which
    returns info about said file. Passing empty data to this
    method will uninstall the file.
GetACFInfo method returns the ACF contents, expiration date
    of the acf file, and if it is installed.