### PR TITLE
Add a new intf "GeneratedBy"

### DIFF
--- a/gen/xyz/openbmc_project/Common/GeneratedBy/meson.build
+++ b/gen/xyz/openbmc_project/Common/GeneratedBy/meson.build
@@ -1,0 +1,14 @@
+# Generated file; do not modify.
+generated_sources += custom_target(
+    'xyz/openbmc_project/Common/GeneratedBy__cpp'.underscorify(),
+    input: [ '../../../../../yaml/xyz/openbmc_project/Common/GeneratedBy.interface.yaml',  ],
+    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'cpp',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../yaml',
+        'xyz/openbmc_project/Common/GeneratedBy',
+    ],
+)
+

--- a/gen/xyz/openbmc_project/Common/meson.build
+++ b/gen/xyz/openbmc_project/Common/meson.build
@@ -82,6 +82,20 @@ generated_others += custom_target(
     ],
 )
 
+subdir('GeneratedBy')
+generated_others += custom_target(
+    'xyz/openbmc_project/Common/GeneratedBy__markdown'.underscorify(),
+    input: [ '../../../../yaml/xyz/openbmc_project/Common/GeneratedBy.interface.yaml',  ],
+    output: [ 'GeneratedBy.md' ],
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'markdown',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../yaml',
+        'xyz/openbmc_project/Common/GeneratedBy',
+    ],
+)
+
 subdir('ObjectPath')
 generated_others += custom_target(
     'xyz/openbmc_project/Common/ObjectPath__markdown'.underscorify(),

--- a/yaml/xyz/openbmc_project/Common/GeneratedBy.interface.yaml
+++ b/yaml/xyz/openbmc_project/Common/GeneratedBy.interface.yaml
@@ -1,0 +1,8 @@
+description: >
+    Implement to provide unique user id on user requested activity
+properties:
+    - name: GeneratorId
+      type: string
+      description: >
+          Unique Id of the user who initiated the respective
+          operation.

--- a/yaml/xyz/openbmc_project/Dump/Create.interface.yaml
+++ b/yaml/xyz/openbmc_project/Dump/Create.interface.yaml
@@ -47,3 +47,12 @@ methods:
         - xyz.openbmc_project.Dump.Create.Error.QuotaExceeded
         - xyz.openbmc_project.Common.Error.NotAllowed
         - xyz.openbmc_project.Common.Error.InvalidArgument
+enumerations:
+    - name: CreateParameters
+      description: >
+          Additional parameters for creating the dump.
+      values:
+        - name: 'GeneratorId'
+          description: >
+              A unique id of the user that initiated the dump creation. The
+              value must be a string.


### PR DESCRIPTION
This interface can be implemented by the dbus objects
that has a requirement to store the unique id of the
user that has initiated the activity. This id is
stored in the "GeneratorId" property.

Design doc at: https://gerrit.openbmc-project.xyz/c/openbmc/docs/+/47446

Gerrit review: https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-dbus-interfaces/+/47057

Signed-off-by: Asmitha Karunanithi <asmitk01@in.ibm.com>
Change-Id: I309252e07a968565a26870710e3965608eb003dc