### PR TITLE
VPD Error interface UnknownSystemType supported

### DIFF
--- a/yaml/com/ibm/VPD.errors.yaml
+++ b/yaml/com/ibm/VPD.errors.yaml
@@ -25,3 +25,8 @@
   description: Invalid Json file.
 - name: DbusFailure
   description: DBus error occurred.
+- name: UnknownSystemType
+  description: Could not determine which device tree to switch to,
+               as system type is unknown.
+               Please check the HW and IM keywords in the system VPD
+               and check if they are programmed correctly.


### PR DESCRIPTION
DevTree gets selected based on HW and IM of the system VPD.
If we get anything unexpected from these keywords, it couldn't
determine which systemType it is and so shouldn't load DevTree.
A PEL with this error interface UnknownSystemType will be logged
and break the booting process there itself.

Signed-off-by: Alpana Kumari <alpankum@in.ibm.com>
Change-Id: I0437f4db87b4ab556d7c5433a861689c682fafe4