### PR TITLE
Add setMode method to OCC PassThrough interface

### DIFF
--- a/yaml/org/open_power/OCC/PassThrough.interface.yaml
+++ b/yaml/org/open_power/OCC/PassThrough.interface.yaml
@@ -24,3 +24,22 @@ methods:
               An array of integers representing the response. This
               should still be bytes worth of data (as though using array[byte]),
               so each entry in the array should pack as many bytes as possible.
+
+    - name: SetMode
+      description: >
+          Change the power mode of the system.
+      parameters:
+        - name: mode
+          type: byte
+          description: >
+              Desired power mode of the system.
+        - name: frequencyPoint
+          type: uint16
+          description: >
+              Frequency point required by some power modes.
+      returns:
+        - name: status
+          type: boolean
+          description: >
+              Returns true if the mode change was accepted.
+


### PR DESCRIPTION
This will allow BMC root users to set any Power Modes including OEM modes
that are not available via Redfish.

Tested on Raininer and Everest systems

Change-Id: I5dd6be67120ab14caa1b3a972eb2571e3c821f7d
Signed-off-by: Chris Cain <cjcain@us.ibm.com># When applied, this commit will… (max 50 col)::::