### PR TITLE
VPD Error interface GPIOError supported

### DIFF
--- a/yaml/com/ibm/VPD.errors.yaml
+++ b/yaml/com/ibm/VPD.errors.yaml
@@ -30,3 +30,9 @@
                as system type is unknown.
                Please check the HW and IM keywords in the system VPD
                and check if they are programmed correctly.
+- name: GPIOError
+  description: GPIO error occurred. It could be GPIO line not found,
+               or couldn't request for input/output to it.
+               Need to check it's address on appropriate I2C line.
+  inherits:
+     - xyz.openbmc_project.Common.Callout.IIC


### PR DESCRIPTION
If any GPIO not found or not working as per the command,
a PEL with this error interface GPIOError will be logged.
In that case need to verify it's I2C line and address.

Signed-off-by: Alpana Kumari <alpankum@in.ibm.com>
Change-Id: Ibe660636a28532b182e5418b19e841f446249457