### PR TITLE
com-ibm-dump: Add response code to resource dump entry

### DIFF
--- a/yaml/com/ibm/Dump/Entry/Resource.interface.yaml
+++ b/yaml/com/ibm/Dump/Entry/Resource.interface.yaml
@@ -23,4 +23,32 @@ properties:
       type: string
       description: >
           The password required by host to validate the request.
+    - name: DumpRequestStatus
+      type: enum[self.HostResponse]
+      description: >
+          The host will send a response code for each request to create a
+          resource dump to indicate whether the request is successful or
+          there is an error.
 
+enumerations:
+    - name: HostResponse
+      description: >
+          These are the possible response codes from the host after sending a
+          resource dump request.
+      values:
+        - name: Success
+          description: >
+              Resource dump parameters and ACF data are successfully validated
+        - name: AcfFileInvalid
+          description: >
+              Invalid ACF file
+        - name: PasswordInvalid
+          description: >
+              Password provided is not valid
+        - name: PermissionDenied
+          descVSPtion: >
+              Caller does not have enough privileges to execute the requested
+              VSP string
+        - name: ResourceSelectorInvalid
+          description: >
+              Resource selector(VSP String) provided is not valid


### PR DESCRIPTION
Add new property in the resource dump entry for storing the
response code  returned by the host after requesting a new
resource dump.

Signed-off-by: Dhruvaraj Subhashchandran <dhruvaraj@in.ibm.com>
Change-Id: I55a4de4e2b77c0387fba7412c122c28e9acdde7b