### PR TITLE
inventory.decorator: Add slot number interface

### DIFF
--- a/gen/xyz/openbmc_project/Inventory/Decorator/Slot/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Decorator/Slot/meson.build
@@ -1,0 +1,14 @@
+# Generated file; do not modify.
+generated_sources += custom_target(
+    'xyz/openbmc_project/Inventory/Decorator/Slot__cpp'.underscorify(),
+    input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Decorator/Slot.interface.yaml',  ],
+    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'cpp',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../../yaml',
+        'xyz/openbmc_project/Inventory/Decorator/Slot',
+    ],
+)
+

--- a/gen/xyz/openbmc_project/Inventory/Decorator/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Decorator/meson.build
@@ -181,6 +181,20 @@ generated_others += custom_target(
     ],
 )
 
+subdir('Slot')
+generated_others += custom_target(
+    'xyz/openbmc_project/Inventory/Decorator/Slot__markdown'.underscorify(),
+    input: [ '../../../../../yaml/xyz/openbmc_project/Inventory/Decorator/Slot.interface.yaml',  ],
+    output: [ 'Slot.md' ],
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'markdown',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../yaml',
+        'xyz/openbmc_project/Inventory/Decorator/Slot',
+    ],
+)
+
 subdir('UniqueIdentifier')
 generated_others += custom_target(
     'xyz/openbmc_project/Inventory/Decorator/UniqueIdentifier__markdown'.underscorify(),

--- a/yaml/xyz/openbmc_project/Inventory/Decorator/Slot.interface.yaml
+++ b/yaml/xyz/openbmc_project/Inventory/Decorator/Slot.interface.yaml
@@ -1,0 +1,7 @@
+description: >
+    Implement to provide a slot number for an inventory item.
+properties:
+    - name: SlotNumber
+      type: size
+      description: >
+          The slot number


### PR DESCRIPTION
This interface provides a slot number property for an inventory item.

The initial use case is to hang this on certain
phosphor-inventory-manager paths so that when entity-manager probes on
them it can have $SlotNumber available as a variable to give a stable
sensor name, such as 'PCIe Card $SlotNumber Temp'.

Without this, if say the $index variable is used instead, and then there
is no guarantee which device will have which sensor name, especially for
cards that can be added in any order when the BMC is running.

Stable sensor names are important in the
phosphor-inventory-manager/entity-manager hybrid model where PIM is used
for inventory and EM is just used for config.

There is a LocationCode property already that could possibly be used on
some systems, but on IBM systems at least it contains the system serial
number so would vary from system to system which isn't desired either.

Upstream: https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-dbus-interfaces/+/50984


Signed-off-by: Matt Spinler <spinler@us.ibm.com>
Change-Id: Iea95d7ad123672909799244b0d80f564cb40d425