### PR TITLE
1020: State: New PowerSystemInputs interface

### DIFF
--- a/gen/xyz/openbmc_project/State/Decorator/PowerSystemInputs/meson.build
+++ b/gen/xyz/openbmc_project/State/Decorator/PowerSystemInputs/meson.build
@@ -1,0 +1,14 @@
+# Generated file; do not modify.
+generated_sources += custom_target(
+    'xyz/openbmc_project/State/Decorator/PowerSystemInputs__cpp'.underscorify(),
+    input: [ '../../../../../../yaml/xyz/openbmc_project/State/Decorator/PowerSystemInputs.interface.yaml',  ],
+    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'cpp',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../../yaml',
+        'xyz/openbmc_project/State/Decorator/PowerSystemInputs',
+    ],
+)
+

--- a/gen/xyz/openbmc_project/State/Decorator/meson.build
+++ b/gen/xyz/openbmc_project/State/Decorator/meson.build
@@ -41,3 +41,17 @@ generated_others += custom_target(
     ],
 )
 
+subdir('PowerSystemInputs')
+generated_others += custom_target(
+    'xyz/openbmc_project/State/Decorator/PowerSystemInputs__markdown'.underscorify(),
+    input: [ '../../../../../yaml/xyz/openbmc_project/State/Decorator/PowerSystemInputs.interface.yaml',  ],
+    output: [ 'PowerSystemInputs.md' ],
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'markdown',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../yaml',
+        'xyz/openbmc_project/State/Decorator/PowerSystemInputs',
+    ],
+)
+

--- a/yaml/xyz/openbmc_project/State/Decorator/PowerSystemInputs.interface.yaml
+++ b/yaml/xyz/openbmc_project/State/Decorator/PowerSystemInputs.interface.yaml
@@ -1,0 +1,27 @@
+description: >
+    Implement to describe the status of the power supplied to the chassis by the
+    power supply unit(s). It is expected that the relationship to the chassis is
+    shown by implementing this interface under a multi-object path, such as
+    chassisN/unit[N] where unit can be an individual or group.
+
+properties:
+    - name: Status
+      type: enum[self.Status]
+      default: Good
+      description: >
+        The current status of the power being supplied to the chassis.
+
+enumerations:
+  - name: Status
+    description: >
+      Power status enum.
+    values:
+      - name: Fault
+        description: >
+         The power supply unit(s) are not providing enough power for normal
+         chassis operation, such as in a Brownout/Blackout condition where one
+         or more power supplies report AC loss VIN fault.
+      - name: Good
+        description: >
+         The power supply unit(s) are providing enough power for normal chassis
+         operation.


### PR DESCRIPTION
#### 1020: State: New PowerSystemInputs interface
```
Add a new PowerSystemInputs interface to describe the state of the power
supplied to the chassis via the power supply unit(s), in order to have
state manager handle Brownout conditions as described in design doc:
https://gerrit.openbmc-project.xyz/c/openbmc/docs/+/48015

This interface would be implemented by the phosphor-power repo and the
Status property set to Fault when a Brownout condition is detected.

Change-Id: I7aeea45f7285835fdb97a34706b3eef610d7532d
Signed-off-by: Adriana Kobylak <anoo@us.ibm.com>
```