### PR TITLE
1020: Delete: Add InsufficientPermission error

### DIFF
--- a/yaml/xyz/openbmc_project/Object/Delete.interface.yaml
+++ b/yaml/xyz/openbmc_project/Object/Delete.interface.yaml
@@ -5,6 +5,7 @@ methods:
       description: >
           Delete the object implementing Delete.
       errors:
-        - xyz.openbmc_project.Common.Error.InternalFailure
-        - xyz.openbmc_project.Common.Error.NotAllowed
-        - xyz.openbmc_project.Common.Error.Unavailable
+          - xyz.openbmc_project.Common.Error.InternalFailure
+          - xyz.openbmc_project.Common.Error.NotAllowed
+          - xyz.openbmc_project.Common.Error.Unavailable
+          - xyz.openbmc_project.Common.Error.InsufficientPermission


### PR DESCRIPTION
#### 1020: Delete: Add InsufficientPermission error
```
- The object may not be allowed to delete due to insufficient permission
  for example, the object might be created by the system, and the user
  may not have permission to delete it.

Signed-off-by: Ramesh Iyyar <rameshi1@in.ibm.com>
Change-Id: Ib662bc275cb091ec41b701faa9aad65b2ae6c6fc
```