### PR TITLE
Add Error to Software Version Interface

### DIFF
--- a/yaml/xyz/openbmc_project/Software/Version.errors.yaml
+++ b/yaml/xyz/openbmc_project/Software/Version.errors.yaml
@@ -8,3 +8,11 @@
 - name: AlreadyExists
   description: >
     This image version already exists on the device
+- name: ExpiredAccessKey
+  description: >
+    The build date of the image occurs after the Update Access Key date
+    indicated on the machine. Update will not be possible for this Software
+    version.
+- name: InvalidSignature
+  description: >
+    Signature Validation failed for image version.

--- a/yaml/xyz/openbmc_project/Software/Version.metadata.yaml
+++ b/yaml/xyz/openbmc_project/Software/Version.metadata.yaml
@@ -12,3 +12,12 @@
   meta:
     - str: "IMAGE_VERSION=%s"
       type: string
+- name: ExpiredAccessKey
+  level: ERR
+  meta:
+    - str: "EXP_DATE=%s"
+      type: string
+    - str: "BUILD_ID=%s"
+      type: string
+- name: InvalidSignature
+  level: ERR


### PR DESCRIPTION
This commit adds a InvalidSignature error to the
Software Version interface. It will ensure that
if the error is hit during the verification of
an image, a corresponding error is available to the
user. This will replace the InternalError that the
signature verification currently creates if it
fails.

This commit will also add a ExpiredAccessKey error
to the Software Version interface. It will provide the
user not only with a more specific error, but metadata
indicating the direct cause. This will also replace an
InternalError that the Update Access Key verifier creates
when the criteria is not met.