### PR TITLE
1020: Add Soft Power Cap limit and IPS active properties

### DIFF
--- a/yaml/xyz/openbmc_project/Control/Power/Cap.interface.yaml
+++ b/yaml/xyz/openbmc_project/Control/Power/Cap.interface.yaml
@@ -1,12 +1,13 @@
 description: >
-    Implement to specify a cap on maximum power consumption.
+    Implement to specify the power consumption cap and bounds
 
 properties:
     - name: PowerCap
       type: uint32
       description: >
-          Power cap value. This could for example be specified in absolute
-          wattage. The unit of measurement must be Watts.
+          Power cap value. This is the user specified power cap.  When enabled
+          the power usage of the system will be limited to keep the power at or
+          below this cap.  This value is in Watts.
 
     - name: PowerCapEnable
       type: boolean
@@ -16,10 +17,27 @@ properties:
 
     - name: MinPowerCapValue
       type: uint32
+      flags:
+          - readonly
       default: 0
-      description: The Minimum supported PowerCap reading.
+      description: The Minimum supported PowerCap setting.
 
     - name: MaxPowerCapValue
       type: uint32
+      flags:
+          - readonly
       default: maxint
-      description: The Maximum supported PowerCap reading.
+      description: The Maximum supported PowerCap setting.
+
+    - name: MinSoftPowerCapValue
+      type: uint32
+      flags:
+          - readonly
+      default: 0
+      description: >
+          Minimum supported soft user PowerCap setting.
+          The min soft user PowerCap value is normally less than or equal to
+          the MinPowerCapValue. When the PowerCap is set to any value between
+          MinSoftPowerCapValue and MinPowerCapValue an attempt will be made to
+          maintain the cap but it will not be guaranted.
+

--- a/yaml/xyz/openbmc_project/Control/Power/IdlePowerSaver.interface.yaml
+++ b/yaml/xyz/openbmc_project/Control/Power/IdlePowerSaver.interface.yaml
@@ -32,3 +32,12 @@ properties:
           This property shall indicate the duration in milliseconds the computer
           system is above the ExitUtilizationPercent value before the idle
           power saver is deactivated.
+
+    - name: Active
+      type: boolean
+      flags:
+          - readonly
+      description: >
+          This property shall indicate whether idle power save is currently
+          active on the system. When this is true, the system has reduced power
+          to save energy.


### PR DESCRIPTION
#### 1020: Add Soft Power Cap limit and IPS active properties
```
- Add soft power cap value which defines the limit which can be lower
  then the MinPowerCapValue but will not be guaranteed to be maintained.
- Add Idle Power Saver active property which will indicate if the system
  is currently running at reduced power due to IPS.

Change-Id: I8512e3f8e1b55deba37b45441dc26b85be6a26f9
Signed-off-by: Chris Cain <cjcain@us.ibm.com>
```