### PR TITLE
Topology: PCIeTopology DBus

### DIFF
--- a/gen/com/ibm/PLDM/PCIeTopology/meson.build
+++ b/gen/com/ibm/PLDM/PCIeTopology/meson.build
@@ -1,0 +1,14 @@
+# Generated file; do not modify.
+generated_sources += custom_target(
+    'com/ibm/PLDM/PCIeTopology__cpp'.underscorify(),
+    input: [ '../../../../../yaml/com/ibm/PLDM/PCIeTopology.interface.yaml',  ],
+    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'cpp',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../yaml',
+        'com/ibm/PLDM/PCIeTopology',
+    ],
+)
+

--- a/gen/com/ibm/PLDM/meson.build
+++ b/gen/com/ibm/PLDM/meson.build
@@ -1,0 +1,15 @@
+# Generated file; do not modify.
+subdir('PCIeTopology')
+generated_others += custom_target(
+    'com/ibm/PLDM/PCIeTopology__markdown'.underscorify(),
+    input: [ '../../../../yaml/com/ibm/PLDM/PCIeTopology.interface.yaml',  ],
+    output: [ 'PCIeTopology.md' ],
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'markdown',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../yaml',
+        'com/ibm/PLDM/PCIeTopology',
+    ],
+)
+

--- a/gen/com/ibm/meson.build
+++ b/gen/com/ibm/meson.build
@@ -3,6 +3,7 @@ subdir('Dump')
 subdir('Host')
 subdir('License')
 subdir('Logging')
+subdir('PLDM')
 subdir('VPD')
 generated_others += custom_target(
     'com/ibm/VPD__markdown'.underscorify(),

--- a/yaml/com/ibm/PLDM/PCIeTopology.interface.yaml
+++ b/yaml/com/ibm/PLDM/PCIeTopology.interface.yaml
@@ -1,0 +1,17 @@
+description: >
+      This interface is used by applications on bmc to request
+      the PCIE topology information.
+properties:
+     - name: PCIeTopologyRefresh
+       type: boolean
+       description: >
+         This property when set to 'true' refreshes the
+         topology information. The application which uses this should
+         set it to 'false' when a refresh occurs.
+     - name: SavePCIeTopologyInfo
+       type: boolean
+       description: >
+         This property when set to 'true' saves the topology
+         information. The information is saved
+         in the form of a PEL(Error Log).
+


### PR DESCRIPTION
This commit defines PCIeTopology DBus interface.
this interface is used by applications on bmc to
request the pcie topology information.

Signed-off-by: Pavithra Barithaya <pavithra.b@ibm.com>