### PR TITLE
openpower: Add GetPELJSON method

### DIFF
--- a/yaml/org/open_power/Logging/PEL.interface.yaml
+++ b/yaml/org/open_power/Logging/PEL.interface.yaml
@@ -148,6 +148,24 @@ methods:
     errors:
        - xyz.openbmc_project.Common.Error.InvalidArgument
 
+  - name: GetPELJSON
+    description: >
+        Returns a string containing the JSON representation
+        of the PEL.
+    parameters:
+      - name: bmcLogId
+        type: uint32
+        description: >
+            The BMC event log id of the PEL to retrieve JSON for
+    returns:
+      - name: json
+        type: string
+        description: >
+            The PEL in JSON format
+    errors:
+       - xyz.openbmc_project.Common.Error.InvalidArgument
+       - xyz.openbmc_project.Common.Error.InternalFailure
+
 enumerations:
   - name: RejectionReason
     description: >


### PR DESCRIPTION
This method returns a PEL in JSON format so it can be returned in
Redfish via an OEM attachment.

It's a method and not a property on the PEL.Entry interface because it
is fairly slow and it would bog down GetManagedObjects calls that don't
care about it.

Cherry picking master and fixing up the formatting of the YAML since it's different between master and ibm-openbmc now.

Signed-off-by: Matt Spinler <spinler@us.ibm.com>
Change-Id: I6d04cd4e301980f95736c05dd5e5b027d400d49b