### PR TITLE
Lanes in use property added

### DIFF
--- a/yaml/xyz/openbmc_project/Inventory/Item/PCIeDevice.interface.yaml
+++ b/yaml/xyz/openbmc_project/Inventory/Item/PCIeDevice.interface.yaml
@@ -287,3 +287,18 @@ properties:
       type: string
       description: >
           The name of the Manufacturer for this device.
+
+    - name: LanesInUse
+      type: size
+      default: 0
+      description: >
+          The number of PCIe lanes in use by this device.
+
+associations:
+    - name: upstream_pcie_slot
+      description: >
+          Objects that implement PCIeDevice can optionally implement the
+          upstream_pcie_slot association to provide a link back to a PCIe slot.
+      reverse_name: associated_pcie_device
+      required_endpoint_interfaces:
+        - xyz.openbmc_project.Inventory.Item.PCIeSlot


### PR DESCRIPTION
The commit adds property "LanesInUse" property for PICeDevice
interface.
It will denote the number of PCIe lanes in use by this device.

Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>
Change-Id: If3d1bca4ce8f186391d842e6b6884f8b898aeec0