### PR TITLE
BusId property in PCIeSlot interface

### DIFF
--- a/yaml/xyz/openbmc_project/Inventory/Item/PCIeSlot.interface.yaml
+++ b/yaml/xyz/openbmc_project/Inventory/Item/PCIeSlot.interface.yaml
@@ -25,6 +25,11 @@ properties:
       description: >
           Whether this PCIe slot supports hotplug
 
+    - name: BusId
+      type: size
+      description: >
+          Identifier to detect the PCIe bus linked to the slot.
+
 enumerations:
     - name: Generations
       description: >


### PR DESCRIPTION
The commit adds property BusId to PCIeSlot interfce, the
property will be required to detect the bus on which the
slot resides.

Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>
Change-Id: I4709610c0882dd1f022011ed3f96031d5d853b46