### PR TITLE
Change power cap bounds to be writable

### DIFF
--- a/yaml/xyz/openbmc_project/Control/Power/Cap.interface.yaml
+++ b/yaml/xyz/openbmc_project/Control/Power/Cap.interface.yaml
@@ -15,24 +15,26 @@ properties:
           Power cap enable.  Set to true to enable the PowerCap, false
           to disable it.
 
+    #TODO: These following bounds are currently owned by Settings but need to be
+    #      written by OCC.Control service so must be writable for now.
     - name: MinPowerCapValue
       type: uint32
-      flags:
-          - readonly
+      #flags:
+      #    - readonly
       default: 0
       description: The Minimum supported PowerCap setting.
 
     - name: MaxPowerCapValue
       type: uint32
-      flags:
-          - readonly
+      #flags:
+      #    - readonly
       default: maxint
       description: The Maximum supported PowerCap setting.
 
     - name: MinSoftPowerCapValue
       type: uint32
-      flags:
-          - readonly
+      #flags:
+      #    - readonly
       default: 0
       description: >
           Minimum supported soft user PowerCap setting.


### PR DESCRIPTION
The power cap properties are hosted by Settings. The values need to be
written by OCC.Control service. When occ-control attempts to write
these properties, it gets an error because the values are not writable.

Change-Id: I72ac24ac91ab3fd050a9305a6a07eab96ee7e88b
Signed-off-by: Chris Cain <cjcain@us.ibm.com>