### PR TITLE
Dump: Create: Add Unavailable error

### DIFF
--- a/yaml/xyz/openbmc_project/Dump/Create.interface.yaml
+++ b/yaml/xyz/openbmc_project/Dump/Create.interface.yaml
@@ -47,6 +47,7 @@ methods:
         - xyz.openbmc_project.Dump.Create.Error.QuotaExceeded
         - xyz.openbmc_project.Common.Error.NotAllowed
         - xyz.openbmc_project.Common.Error.InvalidArgument
+        - xyz.openbmc_project.Common.Error.Unavailable
 enumerations:
     - name: CreateParameters
       description: >


### PR DESCRIPTION
Some types of dumps cannot be initiated when another dump
is in progress, return Unavailable error when the dump
cannot be created.

Signed-off-by: Dhruvaraj Subhashchandran <dhruvaraj@in.ibm.com>
Change-Id: I5590181a7d6c31cd40dc1d673924b56a1a38f186

Conflicts:
	yaml/xyz/openbmc_project/Dump/Create.interface.yaml