### PR TITLE
Add support for CableStatus property

### DIFF
--- a/yaml/xyz/openbmc_project/Inventory/Item/Cable.interface.yaml
+++ b/yaml/xyz/openbmc_project/Inventory/Item/Cable.interface.yaml
@@ -17,3 +17,63 @@ properties:
           in user interfaces but this field should not be used for programmatic
           interrogation of a cable beyond ignoring the default value of the
           empty string.
+    - name: CableStatus
+      type: enum[self.Status]
+      default: 'Unknown'
+      description: >
+          The status of the cable. The default status is unknown.
+
+enumerations:
+    - name: Status
+      description: >
+          Possible cable status
+      values:
+          - name: 'Inactive'
+            description: >
+                Cable is inactive.
+
+          - name: 'Running'
+            description: >
+                Cable is running.
+
+          - name: 'PoweredOff'
+            description: >
+                Cable is powered off.
+
+          - name: 'Unknown'
+            description: >
+                Cable status is unknown.
+
+associations:
+    - name: downstream_chassis
+      description: >
+          Objects that implement Cable can optionally implement the
+          downstream_chassis association to provide a link to the
+          chassis.
+      reverse_name: attached_cables
+      required_endpoint_interfaces:
+        - xyz.openbmc_project.Inventory.Item.Chassis
+
+    - name: upstream_chassis
+      description: >
+          Objects that implement Cable can optionally implement the
+          uptream_chassis association to provide a link to the chassis.
+      reverse_name: attached_cables
+        - xyz.openbmc_project.Inventory.Item.Chassis
+
+    - name: upstream_connector
+      description: >
+          Objects that implement Cable can optionally implement the
+          upstream_connector association to provide a link to the
+          connector.
+      reverse_name: attached_cables
+      required_endpoint_interfaces:
+        - xyz.openbmc_project.Inventory.Item.Connector
+    - name: downstream_connector
+      description: >
+          Objects that implement Cable can optionally implement the
+          downstream_connector association to provide a link to the
+          connector.
+      reverse_name: attached_cables
+      required_endpoint_interfaces:
+        - xyz.openbmc_project.Inventory.Item.Connector

--- a/yaml/xyz/openbmc_project/Inventory/Item/Chassis.interface.yaml
+++ b/yaml/xyz/openbmc_project/Inventory/Item/Chassis.interface.yaml
@@ -6,3 +6,15 @@ properties:
       type: string
       description: >
           The type of physical form factor of the chassis.
+
+associations:
+    - name: attached_cables
+      description: >
+          Objects that implement Chassis can optionally implement the
+          attached_cables association to provide a link to one or more
+          cables.
+      reverse_names:
+        - downstream_chassis
+        - upstream_chassis
+      required_endpoint_interfaces:
+        - xyz.openbmc_project.Inventory.Item.Cable

--- a/yaml/xyz/openbmc_project/Inventory/Item/Connector.interface.yaml
+++ b/yaml/xyz/openbmc_project/Inventory/Item/Connector.interface.yaml
@@ -2,3 +2,14 @@ description: >
     Implement to provide connector attributes. A connector is
     typically an external port or a slot into which cables are
     plugged.
+
+associations:
+    - name: attached_cables
+      description: >
+          Objects that implement Connector can optionally implement the
+          attached_cables association to provide a link to the cable.
+      reverse_names:
+        - upstream_connector
+        - downstream_connector
+      required_endpoint_interfaces:
+        - xyz.openbmc_project.Inventory.Item.Cable


### PR DESCRIPTION
This commit adds a new enum property called CableStatus
under the Cable Interface.
This also adds the downstream chassis_associations and connector associations.

Signed-off-by: Pavithra Barithaya <pavithra.b@ibm.com>