### PR TITLE
Default LanesInUse value to int64

### DIFF
--- a/yaml/xyz/openbmc_project/Inventory/Item/PCIeDevice.interface.yaml
+++ b/yaml/xyz/openbmc_project/Inventory/Item/PCIeDevice.interface.yaml
@@ -289,10 +289,12 @@ properties:
           The name of the Manufacturer for this device.
 
     - name: LanesInUse
-      type: size
-      default: 0
+      type: int64
+      default: -1
       description: >
           The number of PCIe lanes in use by this device.
+          Default value of -1 is to accommodate the situation where value of
+          this property cannot be updated due to some unknown reason.
 
 associations:
     - name: upstream_pcie_slot


### PR DESCRIPTION
The commit changes the type and default value for property
LanesInUse in order to accommodate the situation where reason
of not getting this value is unknown.

Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>
Change-Id: If3bccd89382934f4bcf7ccf16f8068153d113d2c