### PR TITLE
Add additional variant types for Notify D-Bus method

### DIFF
--- a/yaml/xyz/openbmc_project/Inventory/Manager.interface.yaml
+++ b/yaml/xyz/openbmc_project/Inventory/Manager.interface.yaml
@@ -12,6 +12,6 @@ methods:
           state managed.
       parameters:
         - name: object
-          type: dict[path,dict[string,dict[string,variant[boolean,size,int64,string,array[byte]]]]]
+          type: dict[path,dict[string,dict[string,variant[boolean,size,int64,uint16,string,array[byte],array[string]]]]]
           description: >
               A dictionary of fully enumerated items to be managed.


### PR DESCRIPTION
Add uint16_t and array[string] as variant types for
Notify method

Defect:SW550463

Signed-off-by: Sagar Srinivas <sagar.srinivas@ibm.com>