### PR TITLE
Add additional DHCP configuration options

### DIFF
--- a/yaml/xyz/openbmc_project/Network/EthernetInterface.interface.yaml
+++ b/yaml/xyz/openbmc_project/Network/EthernetInterface.interface.yaml
@@ -69,7 +69,9 @@ properties:
     - name: IPv6AcceptRA
       type: boolean
       description: >
-          Boolean for accepting router advertisements in IPv6
+          Boolean for accepting router advertisements in IPv6. This control is
+          being deprecated in favor of the DHCPConf enumerations
+          below. Removal of this entry is deferred.
     - name: NICEnabled
       type: boolean
       description: >
@@ -112,9 +114,19 @@ enumerations:
 
     - name: DHCPConf
       description: >
-          A list of the permitted DHCP settings used by systemd.
+          High level definitions of available DHCP states.
+          These definitions do not have a 1:1 correlation to the
+          systemd.network configuration file contents.
+          both: Enable IPv4 DHCP and IPv6 Stateful DHCP
+          v4v6stateless: Enable IPv4 DHCP and IPv6 SLAAC
+          v6: Enable IPv6 Stateful DHCP
+          v6stateless: Enable IPv6 SLAAC
+          v4: Enable IPv4 DHCP
+          none: Disable DHCP for IPv4 and IPv6
       values:
-        - name: both
-        - name: v4
-        - name: v6
-        - name: none
+          - name: both
+          - name: v4v6stateless
+          - name: v6
+          - name: v6stateless
+          - name: v4
+          - name: none


### PR DESCRIPTION
The existing D-Bus DHCPConf enumearation values do not allow IPv6
Stateless DHCP to be assigned. The IPv4 entries are sufficient, as
DHCP for the v4 stack is truly a boolean.

IPv6 is, at minimum, a ternary control. Adding new enumerations allows
the IPv6 configruation to be done in a more abstract fashion than the
current IPv6AcceptRA D-Bus entry. This D-Bus entry is a direct
reflection of how systemd-networkd manages Routint Advertisement, and
by extension DHCPv6. Only phosphor-network needs this knowledge.

Tested:
The changes compile.
Also, in combination with changes made to phosphor-network, many
busctl set/get property commands were issued to confirm the
enumerations were performing as expected.

Change-Id: I42a46549fed8b2d2187ea6a7eb7278c63b84bbef
Signed-off-by: Johnathan Mantey <johnathanx.mantey@intel.com>