### PR TITLE
treewide: use more specific object_path type

### DIFF
--- a/yaml/org/open_power/HardwareIsolation/Create.interface.yaml
+++ b/yaml/org/open_power/HardwareIsolation/Create.interface.yaml
@@ -23,12 +23,12 @@ methods:
           description: >
               The severity of isolating hardware.
         - name: BmcErrorLog
-          type: path
+          type: object_path
           description: >
               The BMC error log caused the isolation of hardware.
       returns:
         - name: Path
-          type: path
+          type: object_path
           description: >
               The path of created xyz.openbmc_project.HardwareIsolation.Entry
               object.


### PR DESCRIPTION
The sdbus++ tool allows the YAML to specify either "path" or "object_path".  Switch to "object_path" everywhere for consistency and clarity.

Change-Id: Id83fe5bc1b6c803eb2fc554c8d3353ec7f4e4744
Signed-off-by: Adriana Kobylak <anoo@us.ibm.com>