### PR TITLE
PCIeLink and PCIeTopology DBus Interfaces

### DIFF
--- a/gen/com/ibm/Control/Host/PCIeLink/meson.build
+++ b/gen/com/ibm/Control/Host/PCIeLink/meson.build
@@ -1,0 +1,14 @@
+# Generated file; do not modify.
+generated_sources += custom_target(
+    'com/ibm/Control/Host/PCIeLink__cpp'.underscorify(),
+    input: [ '../../../../../../yaml/com/ibm/Control/Host/PCIeLink.interface.yaml',  ],
+    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'cpp',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../../yaml',
+        'com/ibm/Control/Host/PCIeLink',
+    ],
+)
+

--- a/gen/com/ibm/Control/Host/meson.build
+++ b/gen/com/ibm/Control/Host/meson.build
@@ -1,0 +1,15 @@
+# Generated file; do not modify.
+subdir('PCIeLink')
+generated_others += custom_target(
+    'com/ibm/Control/Host/PCIeLink__markdown'.underscorify(),
+    input: [ '../../../../../yaml/com/ibm/Control/Host/PCIeLink.interface.yaml',  ],
+    output: [ 'PCIeLink.md' ],
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'markdown',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../yaml',
+        'com/ibm/Control/Host/PCIeLink',
+    ],
+)
+

--- a/gen/com/ibm/Control/meson.build
+++ b/gen/com/ibm/Control/meson.build
@@ -1,0 +1,2 @@
+# Generated file; do not modify.
+subdir('Host')

--- a/gen/com/ibm/PLDM/PCIeTopology/meson.build
+++ b/gen/com/ibm/PLDM/PCIeTopology/meson.build
@@ -1,0 +1,14 @@
+# Generated file; do not modify.
+generated_sources += custom_target(
+    'com/ibm/PLDM/PCIeTopology__cpp'.underscorify(),
+    input: [ '../../../../../yaml/com/ibm/PLDM/PCIeTopology.interface.yaml',  ],
+    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'cpp',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../yaml',
+        'com/ibm/PLDM/PCIeTopology',
+    ],
+)
+

--- a/gen/com/ibm/PLDM/meson.build
+++ b/gen/com/ibm/PLDM/meson.build
@@ -1,0 +1,15 @@
+# Generated file; do not modify.
+subdir('PCIeTopology')
+generated_others += custom_target(
+    'com/ibm/PLDM/PCIeTopology__markdown'.underscorify(),
+    input: [ '../../../../yaml/com/ibm/PLDM/PCIeTopology.interface.yaml',  ],
+    output: [ 'PCIeTopology.md' ],
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'markdown',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../yaml',
+        'com/ibm/PLDM/PCIeTopology',
+    ],
+)
+

--- a/gen/com/ibm/meson.build
+++ b/gen/com/ibm/meson.build
@@ -1,7 +1,9 @@
 # Generated file; do not modify.
+subdir('Control')
 subdir('Dump')
 subdir('License')
 subdir('Logging')
+subdir('PLDM')
 subdir('VPD')
 subdir('Host')
 generated_others += custom_target(

--- a/yaml/com/ibm/Control/Host/PCIeLink.interface.yaml
+++ b/yaml/com/ibm/Control/Host/PCIeLink.interface.yaml
@@ -1,0 +1,11 @@
+description: >
+    PCIe Link Interface is used to reset the PCIe link.
+properties:
+    - name: linkReset
+      type: boolean
+      default: false
+      description: >
+          When set to true resets the PCIe Link. The service
+          which monitors this property moves it back to the
+          default.
+

--- a/yaml/com/ibm/PCIeTopology.interface.yaml
+++ b/yaml/com/ibm/PCIeTopology.interface.yaml
@@ -1,0 +1,17 @@
+description: >
+      This interface is used by applications on bmc to request
+      the PCIE topology information.
+properties:
+     - name: PCIeTopologyRefresh
+       type: boolean
+       description: >
+         This property when set to 'true' refreshes the
+         topology information. The application which uses this should
+         set it to 'false' when a refresh occurs.
+     - name: SavePCIeTopologyInfo
+       type: boolean
+       description: >
+         This property when set to 'true' saves the topology
+         information. The information is saved
+         in the form of a PEL(Error Log).
+

--- a/yaml/xyz/openbmc_project/Inventory/Item/Cable.interface.yaml
+++ b/yaml/xyz/openbmc_project/Inventory/Item/Cable.interface.yaml
@@ -17,3 +17,58 @@ properties:
           user interfaces but this field should not be used for programmatic
           interrogation of a cable beyond ignoring the default value of the
           empty string.
+    - name: CableStatus
+      type: enum[self.Status]
+      default: 'Unknown'
+      description: >
+          The status of the cable. The default status is unknown.
+enumerations:
+    - name: Status
+      description: >
+          Possible cable status
+      values:
+          - name: 'Inactive'
+            description: >
+                Cable is inactive.
+          - name: 'Running'
+            description: >
+                Cable is running.
+          - name: 'PoweredOff'
+            description: >
+                Cable is powered off.
+          - name: 'Unknown'
+            description: >
+                Cable status is unknown.
+associations:
+    - name: downstream_chassis
+      description: >
+          Objects that implement Cable can optionally implement the
+          downstream_chassis association to provide a link to the
+          chassis.
+      reverse_name: attached_cables
+      required_endpoint_interfaces:
+        - xyz.openbmc_project.Inventory.Item.Chassis
+
+    - name: upstream_chassis
+      description: >
+          Objects that implement Cable can optionally implement the
+          uptream_chassis association to provide a link to the chassis.
+      reverse_name: attached_cables
+        - xyz.openbmc_project.Inventory.Item.Chassis
+
+    - name: upstream_connector
+      description: >
+          Objects that implement Cable can optionally implement the
+          upstream_connector association to provide a link to the
+          connector.
+      reverse_name: attached_cables
+      required_endpoint_interfaces:
+        - xyz.openbmc_project.Inventory.Item.Connector
+    - name: downstream_connector
+      description: >
+          Objects that implement Cable can optionally implement the
+          downstream_connector association to provide a link to the
+          connector.
+      reverse_name: attached_cables
+      required_endpoint_interfaces:
+        - xyz.openbmc_project.Inventory.Item.Connector

--- a/yaml/xyz/openbmc_project/Inventory/Item/Chassis.interface.yaml
+++ b/yaml/xyz/openbmc_project/Inventory/Item/Chassis.interface.yaml
@@ -54,3 +54,15 @@ associations:
       reverse_name: powering
       required_endpoint_interfaces:
           - xyz.openbmc_project.Inventory.Item.PowerSupply
+
+    - name: attached_cables
+      description: >
+          Objects that implement Chassis can optionally implement the
+          attached_cables association to provide a link to one or more
+          cables.
+      reverse_names:
+        - downstream_chassis
+        - upstream_chassis
+      required_endpoint_interfaces:
+        - xyz.openbmc_project.Inventory.Item.Cable
+

--- a/yaml/xyz/openbmc_project/Inventory/Item/Connector.interface.yaml
+++ b/yaml/xyz/openbmc_project/Inventory/Item/Connector.interface.yaml
@@ -1,3 +1,14 @@
 description: >
     Implement to provide connector attributes. A connector is typically an
     external port or a slot into which cables are plugged.
+
+associations:
+    - name: attached_cables
+      description: >
+          Objects that implement Connector can optionally implement the
+          attached_cables association to provide a link to the cable.
+      reverse_names:
+        - upstream_connector
+        - downstream_connector
+      required_endpoint_interfaces:
+        - xyz.openbmc_project.Inventory.Item.Cable

--- a/yaml/xyz/openbmc_project/Inventory/Item/PCIeDevice.interface.yaml
+++ b/yaml/xyz/openbmc_project/Inventory/Item/PCIeDevice.interface.yaml
@@ -295,10 +295,12 @@ properties:
           The maximum number of PCIe lanes supported by the PCIe Device
 
     - name: LanesInUse
-      type: size
-      default: 0
+      type: int64
+      default: -1
       description: >
           The number of PCIe lanes in use by this device.
+          Default value of -1 is to accommodate the situation where value of
+          this property cannot be updated due to some unknown reason.
 
 associations:
     - name: upstream_pcie_slot

--- a/yaml/xyz/openbmc_project/Inventory/Item/PCIeSlot.interface.yaml
+++ b/yaml/xyz/openbmc_project/Inventory/Item/PCIeSlot.interface.yaml
@@ -25,6 +25,17 @@ properties:
       description: >
           Whether this PCIe slot supports hotplug
 
+     - name: LinkStatus
+      type: enum[self.Status]
+      default: 'Unknown'
+      description: >
+          Status of PCIe bus linked to the slot.
+
+     - name: BusId
+      type: size
+      description: >
+          Identifier to detect the PCIe bus linked to the slot.
+
 enumerations:
     - name: Generations
       description: >
@@ -97,6 +108,29 @@ enumerations:
           - name: "Unknown"
             description: >
                 Type of the PCIe slot is unknown
+    - name: Status
+      description: >
+          Possible link status
+      values:
+          - name: 'Operational'
+            description: >
+                Link is operational
+          - name: 'Degraded'
+            description: >
+                Link is degraded
+          - name: 'Failed'
+            description: >
+                Link failed
+          - name: 'Open'
+            description: >
+                Link is open
+                
+          - name: 'Inactive'
+            description: >
+                Link is inactive
+          - name: 'Unknown'
+            description: >
+                Link status is unknown
 
 associations:
     - name: upstream_processor


### PR DESCRIPTION
This commit
- adds support for com.ibm.Control.Host.PcieLink
interface that hosts a new boolean property called linkReset.
- defines PCIeTopology DBus interface.
This interface is used by applications on bmc to
request the pcie topology information.
- defines new enum property called CableStatus under the Cable Interface.
This also adds the downstream chassis_associations and
connector associations.
- changes the type and default value for property
LanesInUse in order to accommodate the situation where reason
of not getting this value is unknown.
- defines property to hold PCIe link status value
for a given PCIe slot.
- adds property BusId to PCIeSlot interfce, the
property will be required to detect the bus on which the
slot resides.


Signed-off-by: Pavithra Barithaya <pavithra.b@ibm.com>