### PR TITLE
Add Network Static Route D-bus Interface

### DIFF
--- a/gen/xyz/openbmc_project/Network/StaticRoute/meson.build
+++ b/gen/xyz/openbmc_project/Network/StaticRoute/meson.build
@@ -1,0 +1,15 @@
+# Generated file; do not modify.
+generated_sources += custom_target(
+    'xyz/openbmc_project/Network/StaticRoute__cpp'.underscorify(),
+    input: [ '../../../../../yaml/xyz/openbmc_project/Network/StaticRoute.interface.yaml',  ],
+    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'cpp',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../yaml',
+        'xyz/openbmc_project/Network/StaticRoute',
+    ],
+)
+

--- a/gen/xyz/openbmc_project/Network/meson.build
+++ b/gen/xyz/openbmc_project/Network/meson.build
@@ -90,6 +90,21 @@ generated_others += custom_target(
     ],
 )
 
+subdir('StaticRoute')
+generated_others += custom_target(
+    'xyz/openbmc_project/Network/StaticRoute__markdown'.underscorify(),
+    input: [ '../../../../yaml/xyz/openbmc_project/Network/StaticRoute.interface.yaml',  ],
+    output: [ 'StaticRoute.md' ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'markdown',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../yaml',
+        'xyz/openbmc_project/Network/StaticRoute',
+    ],
+)
+
 subdir('SystemConfiguration')
 generated_others += custom_target(
     'xyz/openbmc_project/Network/SystemConfiguration__markdown'.underscorify(),

--- a/yaml/xyz/openbmc_project/Network/StaticRoute.interface.yaml
+++ b/yaml/xyz/openbmc_project/Network/StaticRoute.interface.yaml
@@ -1,0 +1,26 @@
+description: >
+    This interface defines network static routes
+
+properties:
+    - name: Destination
+      type: string
+      description: >
+          The value of this property shall be a destination IP address, only
+          destination network IP address allowed. it does not allow hostname.
+      errors:
+          - xyz.openbmc_project.Common.Error.NotAllowed
+
+    - name: Gateway
+      type: string
+      description: >
+          The value of this property shall be a next hop address assigned to the
+          ethernet interface to reach destination address.
+      errors:
+          - xyz.openbmc_project.Common.Error.NotAllowed
+
+    - name: PrefixLength
+      type: uint32
+      description: >
+          This is the number of network bits in the address.
+      errors:
+          - xyz.openbmc_project.Common.Error.NotAllowed


### PR DESCRIPTION
Static routing provides the network administrator with full control over the routing behavior of the BMC network.

This commit adds static route d-bus interface and properties required.

Change-Id: Ib6abea1a9ce2f55cb54489c334b0072bf4fb726e