### PR TITLE
Add a new interface for VSBK record 

### DIFF
--- a/gen/com/ibm/ipzvpd/VSBK/meson.build
+++ b/gen/com/ibm/ipzvpd/VSBK/meson.build
@@ -1,0 +1,15 @@
+# Generated file; do not modify.
+generated_sources += custom_target(
+    'com/ibm/ipzvpd/VSBK__cpp'.underscorify(),
+    input: [ '../../../../../yaml/com/ibm/ipzvpd/VSBK.interface.yaml',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'cpp',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../yaml',
+        'com/ibm/ipzvpd/VSBK',
+    ],
+)
+

--- a/gen/com/ibm/ipzvpd/meson.build
+++ b/gen/com/ibm/ipzvpd/meson.build
@@ -524,6 +524,21 @@ generated_others += custom_target(
     ],
 )
 
+subdir('VSBK')
+generated_others += custom_target(
+    'com/ibm/ipzvpd/VSBK__markdown'.underscorify(),
+    input: [ '../../../../yaml/com/ibm/ipzvpd/VSBK.interface.yaml',  ],
+    output: [ 'VSBK.md' ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'markdown',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../yaml',
+        'com/ibm/ipzvpd/VSBK',
+    ],
+)
+
 subdir('VSBP')
 generated_others += custom_target(
     'com/ibm/ipzvpd/VSBP__markdown'.underscorify(),

--- a/yaml/com/ibm/ipzvpd/VSBK.interface.yaml
+++ b/yaml/com/ibm/ipzvpd/VSBK.interface.yaml
@@ -1,0 +1,67 @@
+description: >
+    Implement to represent the VSBK record in IPZ VPD
+properties:
+    - name: RT
+      type: array[byte]
+      description: >
+          RT keyword. Contains the record name.
+    - name: VZ
+      type: array[byte]
+      description: >
+          VZ keyword. The record version.
+    - name: BR
+      type: array[byte]
+      description: >
+          The system brand.
+    - name: TM
+      type: array[byte]
+      description: >
+          Machine type model - ipSeries.
+    - name: SE
+      type: array[byte]
+      description: >
+          System serial number - ipSeries.
+    - name: SU
+      type: array[byte]
+      description: >
+          System unique ID.
+    - name: RB
+      type: array[byte]
+      description: >
+          RB keyword.
+    - name: WN
+      type: array[byte]
+      description: >
+          WWPN root.
+    - name: RG
+      type: array[byte]
+      description: >
+          Field core override.
+    - name: FV
+      type: array[byte]
+      description: >
+          Firmware version.
+    - name: FC
+      type: array[byte]
+      description: >
+          System enclosure feature code.
+    - name: ES
+      type: array[byte]
+      description: >
+          ES keyword.
+    - name: LX
+      type: array[byte]
+      description: >
+          LX keyword. The load ID data.
+    - name: D0
+      type: array[byte]
+      description: >
+          D0 keyword.
+    - name: F5
+      type: array[byte]
+      description: >
+          F5 keyword.
+    - name: F6
+      type: array[byte]
+      description: >
+          F6 keyword.


### PR DESCRIPTION
This commit will add interface to support the new record(VSBK) and its keywords to store the system backplane's critical data as backup.

The Bonnell BMC is embedded in the system backplane, so if either fails, the backplane should be replaced as a whole. Thus, we must backup the system backplane critical keywords on the VSBK record on the operator panel base EEPROM. Hence VSBK interface being added.

Below is the introspect for VSBK:
busctl introspect xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard/ base_op_panel_blyth com.ibm.ipzvpd.VSBK

NAME                TYPE      SIGNATURE RESULT/VALUE                             FLAGS
.BR                 property  ay        2 83 48                                  emits-change writable
.D0                 property  ay        1 1                                      emits-change writable
.ES                 property  ay        7 66 90 83 48 48 48 51                   emits-change writable
.F5                 property  ay        16 32 32 32 32 32 32 32 32 32 32 32 3... emits-change writable
.F6                 property  ay        0                                        emits-change writable
.FC                 property  ay        8 50 69 52 65 45 48 48 49                emits-change writable
.FV                 property  ay        32 32 32 32 32 32 32 32 32 32 32 32 3... emits-change writable
.LX                 property  ay        8 49 0 4 1 0 48 0 123                    emits-change writable
.RB                 property  ay        4 49 32 32 32                            emits-change writable
.RG                 property  ay        4 0 0 0 0                                emits-change writable
.RT                 property  ay        4 86 83 66 75                            emits-change writable
.SE                 property  ay        7 66 48 48 48 48 48 51                   emits-change writable
.SU                 property  ay        6 0 4 172 31 28 19                       emits-change writable
.TM                 property  ay        8 57 48 50 56 45 50 49 66                emits-change writable
.VZ                 property  ay        2 48 50                                  emits-change writable
.WN                 property  ay        12 67 48 53 48 55 54 48 67 52 56 57 66   emits-change writable