### PR TITLE
1050 update sdbusplus meson

### DIFF
--- a/gen/com/google/gbmc/Hoth/meson.build
+++ b/gen/com/google/gbmc/Hoth/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/google/gbmc/Hoth__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/google/gbmc/Hoth.interface.yaml',  ],
-    output: [ 'error.cpp', 'error.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'error.cpp', 'error.hpp', 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/Control/Host/PCIeLink/meson.build
+++ b/gen/com/ibm/Control/Host/PCIeLink/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/Control/Host/PCIeLink__cpp'.underscorify(),
     input: [ '../../../../../../yaml/com/ibm/Control/Host/PCIeLink.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/Dump/Create/meson.build
+++ b/gen/com/ibm/Dump/Create/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/Dump/Create__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/Dump/Create.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/Dump/Entry/Hardware/meson.build
+++ b/gen/com/ibm/Dump/Entry/Hardware/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/Dump/Entry/Hardware__cpp'.underscorify(),
     input: [ '../../../../../../yaml/com/ibm/Dump/Entry/Hardware.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/Dump/Entry/Hostboot/meson.build
+++ b/gen/com/ibm/Dump/Entry/Hostboot/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/Dump/Entry/Hostboot__cpp'.underscorify(),
     input: [ '../../../../../../yaml/com/ibm/Dump/Entry/Hostboot.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/Dump/Entry/Resource/meson.build
+++ b/gen/com/ibm/Dump/Entry/Resource/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/Dump/Entry/Resource__cpp'.underscorify(),
     input: [ '../../../../../../yaml/com/ibm/Dump/Entry/Resource.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/Dump/Entry/SBE/meson.build
+++ b/gen/com/ibm/Dump/Entry/SBE/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/Dump/Entry/SBE__cpp'.underscorify(),
     input: [ '../../../../../../yaml/com/ibm/Dump/Entry/SBE.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/Host/Target/meson.build
+++ b/gen/com/ibm/Host/Target/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/Host/Target__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/Host/Target.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/License/Entry/LicenseEntry/meson.build
+++ b/gen/com/ibm/License/Entry/LicenseEntry/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/License/Entry/LicenseEntry__cpp'.underscorify(),
     input: [ '../../../../../../yaml/com/ibm/License/Entry/LicenseEntry.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/License/LicenseManager/meson.build
+++ b/gen/com/ibm/License/LicenseManager/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/License/LicenseManager__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/License/LicenseManager.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/Logging/Policy/meson.build
+++ b/gen/com/ibm/Logging/Policy/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/Logging/Policy__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/Logging/Policy.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/PLDM/PCIeTopology/meson.build
+++ b/gen/com/ibm/PLDM/PCIeTopology/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/PLDM/PCIeTopology__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/PLDM/PCIeTopology.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/VPD/Manager/meson.build
+++ b/gen/com/ibm/VPD/Manager/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/VPD/Manager__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/VPD/Manager.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/ipzvpd/CP00/meson.build
+++ b/gen/com/ibm/ipzvpd/CP00/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/ipzvpd/CP00__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/ipzvpd/CP00.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/ipzvpd/CRP0/meson.build
+++ b/gen/com/ibm/ipzvpd/CRP0/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/ipzvpd/CRP0__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/ipzvpd/CRP0.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/ipzvpd/DINF/meson.build
+++ b/gen/com/ibm/ipzvpd/DINF/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/ipzvpd/DINF__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/ipzvpd/DINF.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/ipzvpd/LRP0/meson.build
+++ b/gen/com/ibm/ipzvpd/LRP0/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/ipzvpd/LRP0__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/ipzvpd/LRP0.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/ipzvpd/LRP1/meson.build
+++ b/gen/com/ibm/ipzvpd/LRP1/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/ipzvpd/LRP1__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/ipzvpd/LRP1.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/ipzvpd/LRP2/meson.build
+++ b/gen/com/ibm/ipzvpd/LRP2/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/ipzvpd/LRP2__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/ipzvpd/LRP2.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/ipzvpd/LRP3/meson.build
+++ b/gen/com/ibm/ipzvpd/LRP3/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/ipzvpd/LRP3__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/ipzvpd/LRP3.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/ipzvpd/LRP4/meson.build
+++ b/gen/com/ibm/ipzvpd/LRP4/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/ipzvpd/LRP4__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/ipzvpd/LRP4.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/ipzvpd/LRP5/meson.build
+++ b/gen/com/ibm/ipzvpd/LRP5/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/ipzvpd/LRP5__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/ipzvpd/LRP5.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/ipzvpd/LRP6/meson.build
+++ b/gen/com/ibm/ipzvpd/LRP6/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/ipzvpd/LRP6__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/ipzvpd/LRP6.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/ipzvpd/LRP7/meson.build
+++ b/gen/com/ibm/ipzvpd/LRP7/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/ipzvpd/LRP7__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/ipzvpd/LRP7.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/ipzvpd/LWP0/meson.build
+++ b/gen/com/ibm/ipzvpd/LWP0/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/ipzvpd/LWP0__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/ipzvpd/LWP0.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/ipzvpd/LWP1/meson.build
+++ b/gen/com/ibm/ipzvpd/LWP1/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/ipzvpd/LWP1__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/ipzvpd/LWP1.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/ipzvpd/LWP2/meson.build
+++ b/gen/com/ibm/ipzvpd/LWP2/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/ipzvpd/LWP2__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/ipzvpd/LWP2.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/ipzvpd/LWP3/meson.build
+++ b/gen/com/ibm/ipzvpd/LWP3/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/ipzvpd/LWP3__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/ipzvpd/LWP3.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/ipzvpd/LWP4/meson.build
+++ b/gen/com/ibm/ipzvpd/LWP4/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/ipzvpd/LWP4__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/ipzvpd/LWP4.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/ipzvpd/LWP5/meson.build
+++ b/gen/com/ibm/ipzvpd/LWP5/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/ipzvpd/LWP5__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/ipzvpd/LWP5.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/ipzvpd/LWP6/meson.build
+++ b/gen/com/ibm/ipzvpd/LWP6/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/ipzvpd/LWP6__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/ipzvpd/LWP6.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/ipzvpd/LWP7/meson.build
+++ b/gen/com/ibm/ipzvpd/LWP7/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/ipzvpd/LWP7__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/ipzvpd/LWP7.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/ipzvpd/LXR0/meson.build
+++ b/gen/com/ibm/ipzvpd/LXR0/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/ipzvpd/LXR0__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/ipzvpd/LXR0.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/ipzvpd/Location/meson.build
+++ b/gen/com/ibm/ipzvpd/Location/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/ipzvpd/Location__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/ipzvpd/Location.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/ipzvpd/MER0/meson.build
+++ b/gen/com/ibm/ipzvpd/MER0/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/ipzvpd/MER0__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/ipzvpd/MER0.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/ipzvpd/PSPD/meson.build
+++ b/gen/com/ibm/ipzvpd/PSPD/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/ipzvpd/PSPD__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/ipzvpd/PSPD.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/ipzvpd/UTIL/meson.build
+++ b/gen/com/ibm/ipzvpd/UTIL/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/ipzvpd/UTIL__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/ipzvpd/UTIL.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/ipzvpd/VCEN/meson.build
+++ b/gen/com/ibm/ipzvpd/VCEN/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/ipzvpd/VCEN__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/ipzvpd/VCEN.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/ipzvpd/VCFG/meson.build
+++ b/gen/com/ibm/ipzvpd/VCFG/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/ipzvpd/VCFG__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/ipzvpd/VCFG.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/ipzvpd/VEIR/meson.build
+++ b/gen/com/ibm/ipzvpd/VEIR/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/ipzvpd/VEIR__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/ipzvpd/VEIR.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/ipzvpd/VER0/meson.build
+++ b/gen/com/ibm/ipzvpd/VER0/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/ipzvpd/VER0__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/ipzvpd/VER0.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/ipzvpd/VINI/meson.build
+++ b/gen/com/ibm/ipzvpd/VINI/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/ipzvpd/VINI__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/ipzvpd/VINI.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/ipzvpd/VMPU/meson.build
+++ b/gen/com/ibm/ipzvpd/VMPU/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/ipzvpd/VMPU__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/ipzvpd/VMPU.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/ipzvpd/VMSC/meson.build
+++ b/gen/com/ibm/ipzvpd/VMSC/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/ipzvpd/VMSC__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/ipzvpd/VMSC.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/ipzvpd/VPRI/meson.build
+++ b/gen/com/ibm/ipzvpd/VPRI/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/ipzvpd/VPRI__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/ipzvpd/VPRI.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/ipzvpd/VR10/meson.build
+++ b/gen/com/ibm/ipzvpd/VR10/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/ipzvpd/VR10__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/ipzvpd/VR10.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/ipzvpd/VRML/meson.build
+++ b/gen/com/ibm/ipzvpd/VRML/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/ipzvpd/VRML__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/ipzvpd/VRML.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/ipzvpd/VRTN/meson.build
+++ b/gen/com/ibm/ipzvpd/VRTN/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/ipzvpd/VRTN__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/ipzvpd/VRTN.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/ipzvpd/VSBP/meson.build
+++ b/gen/com/ibm/ipzvpd/VSBP/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/ipzvpd/VSBP__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/ipzvpd/VSBP.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/ipzvpd/VSRC/meson.build
+++ b/gen/com/ibm/ipzvpd/VSRC/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/ipzvpd/VSRC__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/ipzvpd/VSRC.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/ipzvpd/VSYS/meson.build
+++ b/gen/com/ibm/ipzvpd/VSYS/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/ipzvpd/VSYS__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/ipzvpd/VSYS.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/ipzvpd/VW10/meson.build
+++ b/gen/com/ibm/ipzvpd/VW10/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/ipzvpd/VW10__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/ipzvpd/VW10.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/ibm/ipzvpd/VWML/meson.build
+++ b/gen/com/ibm/ipzvpd/VWML/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/ibm/ipzvpd/VWML__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/ibm/ipzvpd/VWML.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/intel/Control/NMISource/meson.build
+++ b/gen/com/intel/Control/NMISource/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/intel/Control/NMISource__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/intel/Control/NMISource.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/intel/Control/OCOTShutdownPolicy/meson.build
+++ b/gen/com/intel/Control/OCOTShutdownPolicy/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/intel/Control/OCOTShutdownPolicy__cpp'.underscorify(),
     input: [ '../../../../../yaml/com/intel/Control/OCOTShutdownPolicy.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/com/intel/Protocol/PECI/Raw/meson.build
+++ b/gen/com/intel/Protocol/PECI/Raw/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'com/intel/Protocol/PECI/Raw__cpp'.underscorify(),
     input: [ '../../../../../../yaml/com/intel/Protocol/PECI/Raw.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/meson.build
+++ b/gen/meson.build
@@ -5,10 +5,10 @@ sdbuspp_gen_meson_ver = run_command(
     check: true,
 ).stdout().strip().split('\n')[0]
 
-if sdbuspp_gen_meson_ver != 'sdbus++-gen-meson version 5'
+if sdbuspp_gen_meson_ver != 'sdbus++-gen-meson version 6'
     warning('Generated meson files from wrong version of sdbus++-gen-meson.')
     warning(
-        'Expected "sdbus++-gen-meson version 5", got:',
+        'Expected "sdbus++-gen-meson version 6", got:',
         sdbuspp_gen_meson_ver
     )
 endif

--- a/gen/org/freedesktop/UPower/Device/meson.build
+++ b/gen/org/freedesktop/UPower/Device/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'org/freedesktop/UPower/Device__cpp'.underscorify(),
     input: [ '../../../../../yaml/org/freedesktop/UPower/Device.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/org/open_power/Control/Host/meson.build
+++ b/gen/org/open_power/Control/Host/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'org/open_power/Control/Host__cpp'.underscorify(),
     input: [ '../../../../../yaml/org/open_power/Control/Host.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/org/open_power/Control/TPM/SecurityKeys/meson.build
+++ b/gen/org/open_power/Control/TPM/SecurityKeys/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'org/open_power/Control/TPM/SecurityKeys__cpp'.underscorify(),
     input: [ '../../../../../../yaml/org/open_power/Control/TPM/SecurityKeys.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/org/open_power/HardwareIsolation/Create/meson.build
+++ b/gen/org/open_power/HardwareIsolation/Create/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'org/open_power/HardwareIsolation/Create__cpp'.underscorify(),
     input: [ '../../../../../yaml/org/open_power/HardwareIsolation/Create.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/org/open_power/Inventory/Decorator/Asset/meson.build
+++ b/gen/org/open_power/Inventory/Decorator/Asset/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'org/open_power/Inventory/Decorator/Asset__cpp'.underscorify(),
     input: [ '../../../../../../yaml/org/open_power/Inventory/Decorator/Asset.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/org/open_power/Logging/PEL/Entry/meson.build
+++ b/gen/org/open_power/Logging/PEL/Entry/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'org/open_power/Logging/PEL/Entry__cpp'.underscorify(),
     input: [ '../../../../../../yaml/org/open_power/Logging/PEL/Entry.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/org/open_power/Logging/PEL/meson.build
+++ b/gen/org/open_power/Logging/PEL/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'org/open_power/Logging/PEL__cpp'.underscorify(),
     input: [ '../../../../../yaml/org/open_power/Logging/PEL.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/org/open_power/OCC/PassThrough/meson.build
+++ b/gen/org/open_power/OCC/PassThrough/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'org/open_power/OCC/PassThrough__cpp'.underscorify(),
     input: [ '../../../../../yaml/org/open_power/OCC/PassThrough.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/org/open_power/OCC/Status/meson.build
+++ b/gen/org/open_power/OCC/Status/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'org/open_power/OCC/Status__cpp'.underscorify(),
     input: [ '../../../../../yaml/org/open_power/OCC/Status.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/org/open_power/Sensor/Aggregation/History/Average/meson.build
+++ b/gen/org/open_power/Sensor/Aggregation/History/Average/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'org/open_power/Sensor/Aggregation/History/Average__cpp'.underscorify(),
     input: [ '../../../../../../../yaml/org/open_power/Sensor/Aggregation/History/Average.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/org/open_power/Sensor/Aggregation/History/Maximum/meson.build
+++ b/gen/org/open_power/Sensor/Aggregation/History/Maximum/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'org/open_power/Sensor/Aggregation/History/Maximum__cpp'.underscorify(),
     input: [ '../../../../../../../yaml/org/open_power/Sensor/Aggregation/History/Maximum.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Association/Definitions/meson.build
+++ b/gen/xyz/openbmc_project/Association/Definitions/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Association/Definitions__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Association/Definitions.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Association/meson.build
+++ b/gen/xyz/openbmc_project/Association/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Association__cpp'.underscorify(),
     input: [ '../../../../yaml/xyz/openbmc_project/Association.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/BIOSConfig/Manager/meson.build
+++ b/gen/xyz/openbmc_project/BIOSConfig/Manager/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/BIOSConfig/Manager__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/BIOSConfig/Manager.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/BIOSConfig/Password/meson.build
+++ b/gen/xyz/openbmc_project/BIOSConfig/Password/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/BIOSConfig/Password__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/BIOSConfig/Password.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Certs/ACF/meson.build
+++ b/gen/xyz/openbmc_project/Certs/ACF/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Certs/ACF__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Certs/ACF.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Certs/Authority/meson.build
+++ b/gen/xyz/openbmc_project/Certs/Authority/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Certs/Authority__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Certs/Authority.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Certs/CSR/Create/meson.build
+++ b/gen/xyz/openbmc_project/Certs/CSR/Create/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Certs/CSR/Create__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Certs/CSR/Create.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Certs/CSR/meson.build
+++ b/gen/xyz/openbmc_project/Certs/CSR/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Certs/CSR__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Certs/CSR.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Certs/Certificate/meson.build
+++ b/gen/xyz/openbmc_project/Certs/Certificate/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Certs/Certificate__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Certs/Certificate.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Certs/Entry/meson.build
+++ b/gen/xyz/openbmc_project/Certs/Entry/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Certs/Entry__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Certs/Entry.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Certs/Install/meson.build
+++ b/gen/xyz/openbmc_project/Certs/Install/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Certs/Install__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Certs/Install.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Certs/InstallAll/meson.build
+++ b/gen/xyz/openbmc_project/Certs/InstallAll/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Certs/InstallAll__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Certs/InstallAll.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Certs/Replace/meson.build
+++ b/gen/xyz/openbmc_project/Certs/Replace/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Certs/Replace__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Certs/Replace.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Certs/ReplaceAll/meson.build
+++ b/gen/xyz/openbmc_project/Certs/ReplaceAll/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Certs/ReplaceAll__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Certs/ReplaceAll.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Channel/ChannelAccess/meson.build
+++ b/gen/xyz/openbmc_project/Channel/ChannelAccess/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Channel/ChannelAccess__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Channel/ChannelAccess.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Chassis/Buttons/Button/meson.build
+++ b/gen/xyz/openbmc_project/Chassis/Buttons/Button/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Chassis/Buttons/Button__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Chassis/Buttons/Button.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Chassis/Buttons/HostSelector/meson.build
+++ b/gen/xyz/openbmc_project/Chassis/Buttons/HostSelector/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Chassis/Buttons/HostSelector__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Chassis/Buttons/HostSelector.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Chassis/Buttons/ID/meson.build
+++ b/gen/xyz/openbmc_project/Chassis/Buttons/ID/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Chassis/Buttons/ID__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Chassis/Buttons/ID.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Chassis/Buttons/NMI/meson.build
+++ b/gen/xyz/openbmc_project/Chassis/Buttons/NMI/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Chassis/Buttons/NMI__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Chassis/Buttons/NMI.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Chassis/Buttons/Power/meson.build
+++ b/gen/xyz/openbmc_project/Chassis/Buttons/Power/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Chassis/Buttons/Power__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Chassis/Buttons/Power.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Chassis/Buttons/Reset/meson.build
+++ b/gen/xyz/openbmc_project/Chassis/Buttons/Reset/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Chassis/Buttons/Reset__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Chassis/Buttons/Reset.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Chassis/Control/NMISource/meson.build
+++ b/gen/xyz/openbmc_project/Chassis/Control/NMISource/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Chassis/Control/NMISource__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Chassis/Control/NMISource.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Chassis/Control/Power/meson.build
+++ b/gen/xyz/openbmc_project/Chassis/Control/Power/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Chassis/Control/Power__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Chassis/Control/Power.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Chassis/Intrusion/meson.build
+++ b/gen/xyz/openbmc_project/Chassis/Intrusion/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Chassis/Intrusion__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Chassis/Intrusion.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Collection/DeleteAll/meson.build
+++ b/gen/xyz/openbmc_project/Collection/DeleteAll/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Collection/DeleteAll__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Collection/DeleteAll.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Common/FactoryReset/meson.build
+++ b/gen/xyz/openbmc_project/Common/FactoryReset/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Common/FactoryReset__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Common/FactoryReset.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Common/FilePath/meson.build
+++ b/gen/xyz/openbmc_project/Common/FilePath/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Common/FilePath__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Common/FilePath.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Common/GeneratedBy/meson.build
+++ b/gen/xyz/openbmc_project/Common/GeneratedBy/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Common/GeneratedBy__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Common/GeneratedBy.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Common/ObjectPath/meson.build
+++ b/gen/xyz/openbmc_project/Common/ObjectPath/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Common/ObjectPath__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Common/ObjectPath.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Common/OriginatedBy/meson.build
+++ b/gen/xyz/openbmc_project/Common/OriginatedBy/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Common/OriginatedBy__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Common/OriginatedBy.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Common/Progress/meson.build
+++ b/gen/xyz/openbmc_project/Common/Progress/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Common/Progress__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Common/Progress.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Common/TFTP/meson.build
+++ b/gen/xyz/openbmc_project/Common/TFTP/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Common/TFTP__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Common/TFTP.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Common/UUID/meson.build
+++ b/gen/xyz/openbmc_project/Common/UUID/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Common/UUID__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Common/UUID.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Condition/HostFirmware/meson.build
+++ b/gen/xyz/openbmc_project/Condition/HostFirmware/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Condition/HostFirmware__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Condition/HostFirmware.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Control/Boot/Mode/meson.build
+++ b/gen/xyz/openbmc_project/Control/Boot/Mode/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Control/Boot/Mode__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Control/Boot/Mode.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Control/Boot/RebootAttempts/meson.build
+++ b/gen/xyz/openbmc_project/Control/Boot/RebootAttempts/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Control/Boot/RebootAttempts__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Control/Boot/RebootAttempts.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Control/Boot/RebootPolicy/meson.build
+++ b/gen/xyz/openbmc_project/Control/Boot/RebootPolicy/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Control/Boot/RebootPolicy__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Control/Boot/RebootPolicy.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Control/Boot/Source/meson.build
+++ b/gen/xyz/openbmc_project/Control/Boot/Source/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Control/Boot/Source__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Control/Boot/Source.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Control/Boot/Type/meson.build
+++ b/gen/xyz/openbmc_project/Control/Boot/Type/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Control/Boot/Type__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Control/Boot/Type.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Control/CFMLimit/meson.build
+++ b/gen/xyz/openbmc_project/Control/CFMLimit/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Control/CFMLimit__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Control/CFMLimit.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Control/ChassisCapabilities/meson.build
+++ b/gen/xyz/openbmc_project/Control/ChassisCapabilities/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Control/ChassisCapabilities__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Control/ChassisCapabilities.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Control/FanPwm/meson.build
+++ b/gen/xyz/openbmc_project/Control/FanPwm/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Control/FanPwm__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Control/FanPwm.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Control/FanRedundancy/meson.build
+++ b/gen/xyz/openbmc_project/Control/FanRedundancy/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Control/FanRedundancy__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Control/FanRedundancy.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Control/FanSpeed/meson.build
+++ b/gen/xyz/openbmc_project/Control/FanSpeed/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Control/FanSpeed__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Control/FanSpeed.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Control/FieldMode/meson.build
+++ b/gen/xyz/openbmc_project/Control/FieldMode/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Control/FieldMode__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Control/FieldMode.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Control/Host/NMI/meson.build
+++ b/gen/xyz/openbmc_project/Control/Host/NMI/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Control/Host/NMI__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Control/Host/NMI.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Control/Host/TurboAllowed/meson.build
+++ b/gen/xyz/openbmc_project/Control/Host/TurboAllowed/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Control/Host/TurboAllowed__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Control/Host/TurboAllowed.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Control/Host/meson.build
+++ b/gen/xyz/openbmc_project/Control/Host/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Control/Host__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Control/Host.interface.yaml',  ],
-    output: [ 'error.cpp', 'error.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'error.cpp', 'error.hpp', 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Control/MinimumShipLevel/meson.build
+++ b/gen/xyz/openbmc_project/Control/MinimumShipLevel/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Control/MinimumShipLevel__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Control/MinimumShipLevel.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Control/Mode/meson.build
+++ b/gen/xyz/openbmc_project/Control/Mode/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Control/Mode__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Control/Mode.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Control/Power/ACPIPowerState/meson.build
+++ b/gen/xyz/openbmc_project/Control/Power/ACPIPowerState/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Control/Power/ACPIPowerState__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Control/Power/ACPIPowerState.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Control/Power/Cap/meson.build
+++ b/gen/xyz/openbmc_project/Control/Power/Cap/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Control/Power/Cap__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Control/Power/Cap.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Control/Power/CapLimits/meson.build
+++ b/gen/xyz/openbmc_project/Control/Power/CapLimits/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Control/Power/CapLimits__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Control/Power/CapLimits.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Control/Power/IdlePowerSaver/meson.build
+++ b/gen/xyz/openbmc_project/Control/Power/IdlePowerSaver/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Control/Power/IdlePowerSaver__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Control/Power/IdlePowerSaver.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Control/Power/Mode/meson.build
+++ b/gen/xyz/openbmc_project/Control/Power/Mode/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Control/Power/Mode__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Control/Power/Mode.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Control/Power/RestorePolicy/meson.build
+++ b/gen/xyz/openbmc_project/Control/Power/RestorePolicy/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Control/Power/RestorePolicy__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Control/Power/RestorePolicy.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Control/PowerSupplyAttributes/meson.build
+++ b/gen/xyz/openbmc_project/Control/PowerSupplyAttributes/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Control/PowerSupplyAttributes__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Control/PowerSupplyAttributes.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Control/PowerSupplyRedundancy/meson.build
+++ b/gen/xyz/openbmc_project/Control/PowerSupplyRedundancy/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Control/PowerSupplyRedundancy__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Control/PowerSupplyRedundancy.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Control/Processor/CurrentOperatingConfig/meson.build
+++ b/gen/xyz/openbmc_project/Control/Processor/CurrentOperatingConfig/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Control/Processor/CurrentOperatingConfig__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Control/Processor/CurrentOperatingConfig.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Control/Security/RestrictionMode/meson.build
+++ b/gen/xyz/openbmc_project/Control/Security/RestrictionMode/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Control/Security/RestrictionMode__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Control/Security/RestrictionMode.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Control/Security/SpecialMode/meson.build
+++ b/gen/xyz/openbmc_project/Control/Security/SpecialMode/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Control/Security/SpecialMode__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Control/Security/SpecialMode.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Control/Service/Attributes/meson.build
+++ b/gen/xyz/openbmc_project/Control/Service/Attributes/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Control/Service/Attributes__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Control/Service/Attributes.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Control/Service/SocketAttributes/meson.build
+++ b/gen/xyz/openbmc_project/Control/Service/SocketAttributes/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Control/Service/SocketAttributes__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Control/Service/SocketAttributes.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Control/TPM/Policy/meson.build
+++ b/gen/xyz/openbmc_project/Control/TPM/Policy/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Control/TPM/Policy__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Control/TPM/Policy.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Control/ThermalMode/meson.build
+++ b/gen/xyz/openbmc_project/Control/ThermalMode/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Control/ThermalMode__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Control/ThermalMode.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Control/VoltageRegulatorControl/meson.build
+++ b/gen/xyz/openbmc_project/Control/VoltageRegulatorControl/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Control/VoltageRegulatorControl__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Control/VoltageRegulatorControl.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Control/VoltageRegulatorMode/meson.build
+++ b/gen/xyz/openbmc_project/Control/VoltageRegulatorMode/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Control/VoltageRegulatorMode__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Control/VoltageRegulatorMode.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Dump/Create/meson.build
+++ b/gen/xyz/openbmc_project/Dump/Create/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Dump/Create__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Dump/Create.interface.yaml',  ],
-    output: [ 'error.cpp', 'error.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'error.cpp', 'error.hpp', 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Dump/Entry/BMC/meson.build
+++ b/gen/xyz/openbmc_project/Dump/Entry/BMC/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Dump/Entry/BMC__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Dump/Entry/BMC.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Dump/Entry/FaultLog/meson.build
+++ b/gen/xyz/openbmc_project/Dump/Entry/FaultLog/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Dump/Entry/FaultLog__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Dump/Entry/FaultLog.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Dump/Entry/System/meson.build
+++ b/gen/xyz/openbmc_project/Dump/Entry/System/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Dump/Entry/System__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Dump/Entry/System.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Dump/Entry/meson.build
+++ b/gen/xyz/openbmc_project/Dump/Entry/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Dump/Entry__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Dump/Entry.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Dump/NewDump/meson.build
+++ b/gen/xyz/openbmc_project/Dump/NewDump/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Dump/NewDump__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Dump/NewDump.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/HardwareIsolation/Create/meson.build
+++ b/gen/xyz/openbmc_project/HardwareIsolation/Create/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/HardwareIsolation/Create__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/HardwareIsolation/Create.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/HardwareIsolation/Entry/meson.build
+++ b/gen/xyz/openbmc_project/HardwareIsolation/Entry/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/HardwareIsolation/Entry__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/HardwareIsolation/Entry.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Connector/Embedded/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Connector/Embedded/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Connector/Embedded__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Connector/Embedded.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Connector/Slot/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Connector/Slot/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Connector/Slot__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Connector/Slot.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Decorator/Asset/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Decorator/Asset/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Decorator/Asset__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Decorator/Asset.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Decorator/AssetTag/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Decorator/AssetTag/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Decorator/AssetTag__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Decorator/AssetTag.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Decorator/CLEI/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Decorator/CLEI/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Decorator/CLEI__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Decorator/CLEI.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Decorator/Cacheable/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Decorator/Cacheable/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Decorator/Cacheable__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Decorator/Cacheable.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Decorator/Compatible/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Decorator/Compatible/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Decorator/Compatible__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Decorator/Compatible.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Decorator/CoolingType/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Decorator/CoolingType/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Decorator/CoolingType__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Decorator/CoolingType.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Decorator/Dimension/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Decorator/Dimension/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Decorator/Dimension__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Decorator/Dimension.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Decorator/I2CDevice/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Decorator/I2CDevice/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Decorator/I2CDevice__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Decorator/I2CDevice.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Decorator/LocationCode/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Decorator/LocationCode/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Decorator/LocationCode__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Decorator/LocationCode.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Decorator/ManufacturerExt/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Decorator/ManufacturerExt/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Decorator/ManufacturerExt__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Decorator/ManufacturerExt.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Decorator/MeetsMinimumShipLevel/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Decorator/MeetsMinimumShipLevel/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Decorator/MeetsMinimumShipLevel__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Decorator/MeetsMinimumShipLevel.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Decorator/Replaceable/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Decorator/Replaceable/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Decorator/Replaceable__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Decorator/Replaceable.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Decorator/Revision/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Decorator/Revision/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Decorator/Revision__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Decorator/Revision.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Decorator/Slot/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Decorator/Slot/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Decorator/Slot__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Decorator/Slot.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Decorator/UniqueIdentifier/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Decorator/UniqueIdentifier/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Decorator/UniqueIdentifier__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Decorator/UniqueIdentifier.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Decorator/VendorInformation/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Decorator/VendorInformation/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Decorator/VendorInformation__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Decorator/VendorInformation.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Decorator/VoltageControl/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Decorator/VoltageControl/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Decorator/VoltageControl__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Decorator/VoltageControl.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Item/Accelerator/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Item/Accelerator/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Item/Accelerator__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Item/Accelerator.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Item/Battery/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Item/Battery/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Item/Battery__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Item/Battery.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Item/Bmc/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Item/Bmc/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Item/Bmc__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Item/Bmc.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Item/Board/IOBoard/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Item/Board/IOBoard/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Item/Board/IOBoard__cpp'.underscorify(),
     input: [ '../../../../../../../yaml/xyz/openbmc_project/Inventory/Item/Board/IOBoard.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Item/Board/Motherboard/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Item/Board/Motherboard/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Item/Board/Motherboard__cpp'.underscorify(),
     input: [ '../../../../../../../yaml/xyz/openbmc_project/Inventory/Item/Board/Motherboard.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Item/Board/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Item/Board/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Item/Board__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Item/Board.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Item/Cable/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Item/Cable/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Item/Cable__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Item/Cable.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Item/Chassis/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Item/Chassis/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Item/Chassis__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Item/Chassis.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Item/Connector/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Item/Connector/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Item/Connector__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Item/Connector.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Item/Cpu/OperatingConfig/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Item/Cpu/OperatingConfig/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Item/Cpu/OperatingConfig__cpp'.underscorify(),
     input: [ '../../../../../../../yaml/xyz/openbmc_project/Inventory/Item/Cpu/OperatingConfig.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Item/Cpu/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Item/Cpu/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Item/Cpu__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Item/Cpu.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Item/CpuCore/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Item/CpuCore/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Item/CpuCore__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Item/CpuCore.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Item/Dimm/MemoryLocation/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Item/Dimm/MemoryLocation/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Item/Dimm/MemoryLocation__cpp'.underscorify(),
     input: [ '../../../../../../../yaml/xyz/openbmc_project/Inventory/Item/Dimm/MemoryLocation.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Item/Dimm/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Item/Dimm/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Item/Dimm__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Item/Dimm.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Item/DiskBackplane/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Item/DiskBackplane/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Item/DiskBackplane__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Item/DiskBackplane.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Item/Drive/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Item/Drive/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Item/Drive__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Item/Drive.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Item/Ethernet/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Item/Ethernet/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Item/Ethernet__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Item/Ethernet.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Item/FabricAdapter/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Item/FabricAdapter/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Item/FabricAdapter__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Item/FabricAdapter.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Item/Fan/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Item/Fan/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Item/Fan__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Item/Fan.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Item/Global/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Item/Global/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Item/Global__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Item/Global.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Item/MemoryBuffer/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Item/MemoryBuffer/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Item/MemoryBuffer__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Item/MemoryBuffer.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Item/NetworkInterface/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Item/NetworkInterface/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Item/NetworkInterface__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Item/NetworkInterface.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Item/PCIeDevice/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Item/PCIeDevice/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Item/PCIeDevice__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Item/PCIeDevice.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Item/PCIeSlot/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Item/PCIeSlot/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Item/PCIeSlot__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Item/PCIeSlot.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Item/Panel/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Item/Panel/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Item/Panel__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Item/Panel.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Item/PersistentMemory/Partition/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Item/PersistentMemory/Partition/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Item/PersistentMemory/Partition__cpp'.underscorify(),
     input: [ '../../../../../../../yaml/xyz/openbmc_project/Inventory/Item/PersistentMemory/Partition.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Item/PersistentMemory/PowerManagementPolicy/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Item/PersistentMemory/PowerManagementPolicy/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Item/PersistentMemory/PowerManagementPolicy__cpp'.underscorify(),
     input: [ '../../../../../../../yaml/xyz/openbmc_project/Inventory/Item/PersistentMemory/PowerManagementPolicy.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Item/PersistentMemory/SecurityCapabilities/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Item/PersistentMemory/SecurityCapabilities/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Item/PersistentMemory/SecurityCapabilities__cpp'.underscorify(),
     input: [ '../../../../../../../yaml/xyz/openbmc_project/Inventory/Item/PersistentMemory/SecurityCapabilities.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Item/PersistentMemory/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Item/PersistentMemory/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Item/PersistentMemory__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Item/PersistentMemory.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Item/PowerSupply/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Item/PowerSupply/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Item/PowerSupply__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Item/PowerSupply.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Item/Rotor/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Item/Rotor/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Item/Rotor__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Item/Rotor.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Item/Storage/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Item/Storage/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Item/Storage__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Item/Storage.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Item/StorageController/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Item/StorageController/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Item/StorageController__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Item/StorageController.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Item/System/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Item/System/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Item/System__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Item/System.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Item/Tpm/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Item/Tpm/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Item/Tpm__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Item/Tpm.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Item/Volume/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Item/Volume/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Item/Volume__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Item/Volume.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Item/Vrm/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Item/Vrm/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Item/Vrm__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Item/Vrm.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Item/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Item/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Item__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Inventory/Item.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Manager/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Manager/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Manager__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Inventory/Manager.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Source/PLDM/Entity/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Source/PLDM/Entity/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Source/PLDM/Entity__cpp'.underscorify(),
     input: [ '../../../../../../../yaml/xyz/openbmc_project/Inventory/Source/PLDM/Entity.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Inventory/Source/PLDM/FRU/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Source/PLDM/FRU/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Inventory/Source/PLDM/FRU__cpp'.underscorify(),
     input: [ '../../../../../../../yaml/xyz/openbmc_project/Inventory/Source/PLDM/FRU.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Ipmi/SOL/meson.build
+++ b/gen/xyz/openbmc_project/Ipmi/SOL/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Ipmi/SOL__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Ipmi/SOL.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Ipmi/SessionInfo/meson.build
+++ b/gen/xyz/openbmc_project/Ipmi/SessionInfo/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Ipmi/SessionInfo__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Ipmi/SessionInfo.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Led/Group/meson.build
+++ b/gen/xyz/openbmc_project/Led/Group/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Led/Group__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Led/Group.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Led/Physical/meson.build
+++ b/gen/xyz/openbmc_project/Led/Physical/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Led/Physical__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Led/Physical.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Logging/Create/meson.build
+++ b/gen/xyz/openbmc_project/Logging/Create/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Logging/Create__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Logging/Create.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Logging/Entry/meson.build
+++ b/gen/xyz/openbmc_project/Logging/Entry/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Logging/Entry__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Logging/Entry.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Logging/ErrorBlocksTransition/meson.build
+++ b/gen/xyz/openbmc_project/Logging/ErrorBlocksTransition/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Logging/ErrorBlocksTransition__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Logging/ErrorBlocksTransition.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Logging/Event/meson.build
+++ b/gen/xyz/openbmc_project/Logging/Event/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Logging/Event__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Logging/Event.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Logging/IPMI/meson.build
+++ b/gen/xyz/openbmc_project/Logging/IPMI/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Logging/IPMI__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Logging/IPMI.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Logging/Settings/meson.build
+++ b/gen/xyz/openbmc_project/Logging/Settings/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Logging/Settings__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Logging/Settings.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Logging/Syslog/Destination/Mail/Create/meson.build
+++ b/gen/xyz/openbmc_project/Logging/Syslog/Destination/Mail/Create/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Logging/Syslog/Destination/Mail/Create__cpp'.underscorify(),
     input: [ '../../../../../../../../yaml/xyz/openbmc_project/Logging/Syslog/Destination/Mail/Create.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Logging/Syslog/Destination/Mail/Entry/meson.build
+++ b/gen/xyz/openbmc_project/Logging/Syslog/Destination/Mail/Entry/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Logging/Syslog/Destination/Mail/Entry__cpp'.underscorify(),
     input: [ '../../../../../../../../yaml/xyz/openbmc_project/Logging/Syslog/Destination/Mail/Entry.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Logging/Syslog/Destination/Mail/meson.build
+++ b/gen/xyz/openbmc_project/Logging/Syslog/Destination/Mail/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Logging/Syslog/Destination/Mail__cpp'.underscorify(),
     input: [ '../../../../../../../yaml/xyz/openbmc_project/Logging/Syslog/Destination/Mail.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/MCTP/Endpoint/meson.build
+++ b/gen/xyz/openbmc_project/MCTP/Endpoint/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/MCTP/Endpoint__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/MCTP/Endpoint.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Memory/MemoryECC/meson.build
+++ b/gen/xyz/openbmc_project/Memory/MemoryECC/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Memory/MemoryECC__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Memory/MemoryECC.interface.yaml',  ],
-    output: [ 'error.cpp', 'error.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'error.cpp', 'error.hpp', 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Network/Client/Create/meson.build
+++ b/gen/xyz/openbmc_project/Network/Client/Create/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Network/Client/Create__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Network/Client/Create.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Network/Client/meson.build
+++ b/gen/xyz/openbmc_project/Network/Client/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Network/Client__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Network/Client.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Network/DHCPConfiguration/meson.build
+++ b/gen/xyz/openbmc_project/Network/DHCPConfiguration/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Network/DHCPConfiguration__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Network/DHCPConfiguration.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Network/EthernetInterface/meson.build
+++ b/gen/xyz/openbmc_project/Network/EthernetInterface/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Network/EthernetInterface__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Network/EthernetInterface.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Network/Experimental/Bond/meson.build
+++ b/gen/xyz/openbmc_project/Network/Experimental/Bond/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Network/Experimental/Bond__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Network/Experimental/Bond.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Network/Experimental/Tunnel/meson.build
+++ b/gen/xyz/openbmc_project/Network/Experimental/Tunnel/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Network/Experimental/Tunnel__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Network/Experimental/Tunnel.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Network/IP/meson.build
+++ b/gen/xyz/openbmc_project/Network/IP/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Network/IP__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Network/IP.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Network/MACAddress/meson.build
+++ b/gen/xyz/openbmc_project/Network/MACAddress/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Network/MACAddress__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Network/MACAddress.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Network/Neighbor/meson.build
+++ b/gen/xyz/openbmc_project/Network/Neighbor/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Network/Neighbor__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Network/Neighbor.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Network/StaticRoute/meson.build
+++ b/gen/xyz/openbmc_project/Network/StaticRoute/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Network/StaticRoute__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Network/StaticRoute.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Network/SystemConfiguration/meson.build
+++ b/gen/xyz/openbmc_project/Network/SystemConfiguration/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Network/SystemConfiguration__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Network/SystemConfiguration.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Network/VLAN/meson.build
+++ b/gen/xyz/openbmc_project/Network/VLAN/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Network/VLAN__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Network/VLAN.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Nvme/Status/meson.build
+++ b/gen/xyz/openbmc_project/Nvme/Status/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Nvme/Status__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Nvme/Status.interface.yaml',  ],
-    output: [ 'error.cpp', 'error.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'error.cpp', 'error.hpp', 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Object/Delete/meson.build
+++ b/gen/xyz/openbmc_project/Object/Delete/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Object/Delete__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Object/Delete.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Object/Enable/meson.build
+++ b/gen/xyz/openbmc_project/Object/Enable/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Object/Enable__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Object/Enable.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/ObjectMapper/meson.build
+++ b/gen/xyz/openbmc_project/ObjectMapper/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/ObjectMapper__cpp'.underscorify(),
     input: [ '../../../../yaml/xyz/openbmc_project/ObjectMapper.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/PFR/Attributes/meson.build
+++ b/gen/xyz/openbmc_project/PFR/Attributes/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/PFR/Attributes__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/PFR/Attributes.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/PLDM/Event/meson.build
+++ b/gen/xyz/openbmc_project/PLDM/Event/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/PLDM/Event__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/PLDM/Event.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/PLDM/PDR/meson.build
+++ b/gen/xyz/openbmc_project/PLDM/PDR/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/PLDM/PDR__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/PLDM/PDR.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/PLDM/Provider/Certs/Authority/CSR/meson.build
+++ b/gen/xyz/openbmc_project/PLDM/Provider/Certs/Authority/CSR/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/PLDM/Provider/Certs/Authority/CSR__cpp'.underscorify(),
     input: [ '../../../../../../../../yaml/xyz/openbmc_project/PLDM/Provider/Certs/Authority/CSR.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/PLDM/Requester/meson.build
+++ b/gen/xyz/openbmc_project/PLDM/Requester/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/PLDM/Requester__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/PLDM/Requester.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Sensor/Accuracy/meson.build
+++ b/gen/xyz/openbmc_project/Sensor/Accuracy/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Sensor/Accuracy__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Sensor/Accuracy.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Sensor/Threshold/Critical/meson.build
+++ b/gen/xyz/openbmc_project/Sensor/Threshold/Critical/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Sensor/Threshold/Critical__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Sensor/Threshold/Critical.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Sensor/Threshold/HardShutdown/meson.build
+++ b/gen/xyz/openbmc_project/Sensor/Threshold/HardShutdown/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Sensor/Threshold/HardShutdown__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Sensor/Threshold/HardShutdown.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Sensor/Threshold/PerformanceLoss/meson.build
+++ b/gen/xyz/openbmc_project/Sensor/Threshold/PerformanceLoss/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Sensor/Threshold/PerformanceLoss__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Sensor/Threshold/PerformanceLoss.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Sensor/Threshold/SoftShutdown/meson.build
+++ b/gen/xyz/openbmc_project/Sensor/Threshold/SoftShutdown/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Sensor/Threshold/SoftShutdown__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Sensor/Threshold/SoftShutdown.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Sensor/Threshold/Warning/meson.build
+++ b/gen/xyz/openbmc_project/Sensor/Threshold/Warning/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Sensor/Threshold/Warning__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/Sensor/Threshold/Warning.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Sensor/Value/meson.build
+++ b/gen/xyz/openbmc_project/Sensor/Value/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Sensor/Value__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Sensor/Value.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Sensor/ValueMutability/meson.build
+++ b/gen/xyz/openbmc_project/Sensor/ValueMutability/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Sensor/ValueMutability__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Sensor/ValueMutability.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Smbios/MDR_V2/meson.build
+++ b/gen/xyz/openbmc_project/Smbios/MDR_V2/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Smbios/MDR_V2__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Smbios/MDR_V2.interface.yaml',  ],
-    output: [ 'error.cpp', 'error.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'error.cpp', 'error.hpp', 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Software/Activation/meson.build
+++ b/gen/xyz/openbmc_project/Software/Activation/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Software/Activation__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Software/Activation.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Software/ActivationBlocksTransition/meson.build
+++ b/gen/xyz/openbmc_project/Software/ActivationBlocksTransition/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Software/ActivationBlocksTransition__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Software/ActivationBlocksTransition.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Software/ActivationProgress/meson.build
+++ b/gen/xyz/openbmc_project/Software/ActivationProgress/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Software/ActivationProgress__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Software/ActivationProgress.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Software/ApplyOptions/meson.build
+++ b/gen/xyz/openbmc_project/Software/ApplyOptions/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Software/ApplyOptions__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Software/ApplyOptions.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Software/ApplyTime/meson.build
+++ b/gen/xyz/openbmc_project/Software/ApplyTime/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Software/ApplyTime__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Software/ApplyTime.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Software/ExtendedVersion/meson.build
+++ b/gen/xyz/openbmc_project/Software/ExtendedVersion/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Software/ExtendedVersion__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Software/ExtendedVersion.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Software/LID/meson.build
+++ b/gen/xyz/openbmc_project/Software/LID/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Software/LID__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Software/LID.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Software/RedundancyPriority/meson.build
+++ b/gen/xyz/openbmc_project/Software/RedundancyPriority/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Software/RedundancyPriority__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Software/RedundancyPriority.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Software/RequestedRedundancyPriority/meson.build
+++ b/gen/xyz/openbmc_project/Software/RequestedRedundancyPriority/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Software/RequestedRedundancyPriority__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Software/RequestedRedundancyPriority.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Software/Settings/meson.build
+++ b/gen/xyz/openbmc_project/Software/Settings/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Software/Settings__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Software/Settings.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Software/Version/meson.build
+++ b/gen/xyz/openbmc_project/Software/Version/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Software/Version__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Software/Version.interface.yaml',  ],
-    output: [ 'error.cpp', 'error.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'error.cpp', 'error.hpp', 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/State/BMC/meson.build
+++ b/gen/xyz/openbmc_project/State/BMC/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/State/BMC__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/State/BMC.interface.yaml',  ],
-    output: [ 'error.cpp', 'error.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'error.cpp', 'error.hpp', 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/State/BMCRedundancy/meson.build
+++ b/gen/xyz/openbmc_project/State/BMCRedundancy/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/State/BMCRedundancy__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/State/BMCRedundancy.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/State/Boot/PostCode/meson.build
+++ b/gen/xyz/openbmc_project/State/Boot/PostCode/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/State/Boot/PostCode__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/State/Boot/PostCode.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/State/Boot/Progress/meson.build
+++ b/gen/xyz/openbmc_project/State/Boot/Progress/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/State/Boot/Progress__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/State/Boot/Progress.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/State/Boot/Raw/meson.build
+++ b/gen/xyz/openbmc_project/State/Boot/Raw/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/State/Boot/Raw__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/State/Boot/Raw.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/State/Chassis/meson.build
+++ b/gen/xyz/openbmc_project/State/Chassis/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/State/Chassis__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/State/Chassis.interface.yaml',  ],
-    output: [ 'error.cpp', 'error.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'error.cpp', 'error.hpp', 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/State/Decorator/Availability/meson.build
+++ b/gen/xyz/openbmc_project/State/Decorator/Availability/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/State/Decorator/Availability__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/State/Decorator/Availability.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/State/Decorator/OperationalStatus/meson.build
+++ b/gen/xyz/openbmc_project/State/Decorator/OperationalStatus/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/State/Decorator/OperationalStatus__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/State/Decorator/OperationalStatus.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/State/Decorator/PowerState/meson.build
+++ b/gen/xyz/openbmc_project/State/Decorator/PowerState/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/State/Decorator/PowerState__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/State/Decorator/PowerState.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/State/Decorator/PowerSystemInputs/meson.build
+++ b/gen/xyz/openbmc_project/State/Decorator/PowerSystemInputs/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/State/Decorator/PowerSystemInputs__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/State/Decorator/PowerSystemInputs.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/State/Drive/meson.build
+++ b/gen/xyz/openbmc_project/State/Drive/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/State/Drive__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/State/Drive.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/State/Host/meson.build
+++ b/gen/xyz/openbmc_project/State/Host/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/State/Host__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/State/Host.interface.yaml',  ],
-    output: [ 'error.cpp', 'error.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'error.cpp', 'error.hpp', 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/State/OperatingSystem/Status/meson.build
+++ b/gen/xyz/openbmc_project/State/OperatingSystem/Status/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/State/OperatingSystem/Status__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/State/OperatingSystem/Status.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/State/PowerOnHours/meson.build
+++ b/gen/xyz/openbmc_project/State/PowerOnHours/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/State/PowerOnHours__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/State/PowerOnHours.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/State/ScheduledHostTransition/meson.build
+++ b/gen/xyz/openbmc_project/State/ScheduledHostTransition/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/State/ScheduledHostTransition__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/State/ScheduledHostTransition.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/State/Watchdog/meson.build
+++ b/gen/xyz/openbmc_project/State/Watchdog/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/State/Watchdog__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/State/Watchdog.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Telemetry/Report/meson.build
+++ b/gen/xyz/openbmc_project/Telemetry/Report/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Telemetry/Report__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Telemetry/Report.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Telemetry/ReportManager/meson.build
+++ b/gen/xyz/openbmc_project/Telemetry/ReportManager/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Telemetry/ReportManager__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Telemetry/ReportManager.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Telemetry/Trigger/meson.build
+++ b/gen/xyz/openbmc_project/Telemetry/Trigger/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Telemetry/Trigger__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Telemetry/Trigger.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Telemetry/TriggerManager/meson.build
+++ b/gen/xyz/openbmc_project/Telemetry/TriggerManager/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Telemetry/TriggerManager__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Telemetry/TriggerManager.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Time/EpochTime/meson.build
+++ b/gen/xyz/openbmc_project/Time/EpochTime/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Time/EpochTime__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Time/EpochTime.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/Time/Synchronization/meson.build
+++ b/gen/xyz/openbmc_project/Time/Synchronization/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/Time/Synchronization__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/Time/Synchronization.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/User/AccountPolicy/meson.build
+++ b/gen/xyz/openbmc_project/User/AccountPolicy/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/User/AccountPolicy__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/User/AccountPolicy.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/User/Attributes/meson.build
+++ b/gen/xyz/openbmc_project/User/Attributes/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/User/Attributes__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/User/Attributes.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/User/Ldap/Config/meson.build
+++ b/gen/xyz/openbmc_project/User/Ldap/Config/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/User/Ldap/Config__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/User/Ldap/Config.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/User/Ldap/Create/meson.build
+++ b/gen/xyz/openbmc_project/User/Ldap/Create/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/User/Ldap/Create__cpp'.underscorify(),
     input: [ '../../../../../../yaml/xyz/openbmc_project/User/Ldap/Create.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/User/Manager/meson.build
+++ b/gen/xyz/openbmc_project/User/Manager/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/User/Manager__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/User/Manager.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/User/PrivilegeMapper/meson.build
+++ b/gen/xyz/openbmc_project/User/PrivilegeMapper/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/User/PrivilegeMapper__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/User/PrivilegeMapper.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/User/PrivilegeMapperEntry/meson.build
+++ b/gen/xyz/openbmc_project/User/PrivilegeMapperEntry/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/User/PrivilegeMapperEntry__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/User/PrivilegeMapperEntry.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/VirtualMedia/Legacy/meson.build
+++ b/gen/xyz/openbmc_project/VirtualMedia/Legacy/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/VirtualMedia/Legacy__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/VirtualMedia/Legacy.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/VirtualMedia/MountPoint/meson.build
+++ b/gen/xyz/openbmc_project/VirtualMedia/MountPoint/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/VirtualMedia/MountPoint__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/VirtualMedia/MountPoint.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/VirtualMedia/Process/meson.build
+++ b/gen/xyz/openbmc_project/VirtualMedia/Process/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/VirtualMedia/Process__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/VirtualMedia/Process.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/VirtualMedia/Proxy/meson.build
+++ b/gen/xyz/openbmc_project/VirtualMedia/Proxy/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/VirtualMedia/Proxy__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/VirtualMedia/Proxy.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/gen/xyz/openbmc_project/VirtualMedia/Stats/meson.build
+++ b/gen/xyz/openbmc_project/VirtualMedia/Stats/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'xyz/openbmc_project/VirtualMedia/Stats__cpp'.underscorify(),
     input: [ '../../../../../yaml/xyz/openbmc_project/VirtualMedia/Stats.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',


### PR DESCRIPTION
Upstream required we regenerate the meson that utilizes sdbusplus. This PR pulls in the upstream change + the same changes to our downstream-only code.

Upstream: https://github.com/openbmc/phosphor-dbus-interfaces/commit/c096cf78fe626923f81067a5b97283aa856d8b74