### PR TITLE
Add Network Static Route D-bus Interface

### DIFF
--- a/gen/xyz/openbmc_project/Network/StaticRoute/Create/meson.build
+++ b/gen/xyz/openbmc_project/Network/StaticRoute/Create/meson.build
@@ -1,0 +1,15 @@
+# Generated file; do not modify.
+generated_sources += custom_target(
+    'xyz/openbmc_project/Network/StaticRoute/Create__cpp'.underscorify(),
+    input: [ '../../../../../../yaml/xyz/openbmc_project/Network/StaticRoute/Create.interface.yaml',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'cpp',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../../yaml',
+        'xyz/openbmc_project/Network/StaticRoute/Create',
+    ],
+)
+

--- a/gen/xyz/openbmc_project/Network/StaticRoute/meson.build
+++ b/gen/xyz/openbmc_project/Network/StaticRoute/meson.build
@@ -13,3 +13,18 @@ generated_sources += custom_target(
     ],
 )
 
+subdir('Create')
+generated_others += custom_target(
+    'xyz/openbmc_project/Network/StaticRoute/Create__markdown'.underscorify(),
+    input: [ '../../../../../yaml/xyz/openbmc_project/Network/StaticRoute/Create.interface.yaml',  ],
+    output: [ 'Create.md' ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'markdown',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../yaml',
+        'xyz/openbmc_project/Network/StaticRoute/Create',
+    ],
+)
+

--- a/yaml/xyz/openbmc_project/Network/StaticRoute.interface.yaml
+++ b/yaml/xyz/openbmc_project/Network/StaticRoute.interface.yaml
@@ -19,8 +19,15 @@ properties:
           - xyz.openbmc_project.Common.Error.NotAllowed
 
     - name: PrefixLength
-      type: uint32
+      type: size
       description: >
           This is the number of network bits in the address.
+      errors:
+          - xyz.openbmc_project.Common.Error.NotAllowed
+
+    - name: ProtocolType
+      type: enum[xyz.openbmc_project.Network.IP.Protocol]
+      description: >
+          Protocol type can be IPv4 or IPv6 etc.
       errors:
           - xyz.openbmc_project.Common.Error.NotAllowed

--- a/yaml/xyz/openbmc_project/Network/StaticRoute/Create.interface.yaml
+++ b/yaml/xyz/openbmc_project/Network/StaticRoute/Create.interface.yaml
@@ -1,0 +1,29 @@
+description: >
+methods:
+    - name: StaticRoute
+      description: >
+          Create a static route entry.
+      parameters:
+          - name: Destination
+            type: string
+            description: >
+                Destination Address.
+          - name: Gateway
+            type: string
+            description: >
+                Next hop address to reach destination address
+          - name: PrefixLength
+            type: size
+            description: >
+                Number of network bits in the address
+          - name: ProtocolType
+            type: enum[xyz.openbmc_project.Network.IP.Protocol]
+            description: >
+                protocol type can be IPv4 or IPv6 etc.
+      returns:
+          - name: Path
+            type: object_path
+            description: >
+                The path for the created static route object.
+      errors:
+          - xyz.openbmc_project.Common.Error.InvalidArgument


### PR DESCRIPTION
Static routing provides the network administrator with full control over the routing behavior of the BMC network.

This commit adds static route d-bus interface and properties required.

Change-Id: Ib6abea1a9ce2f55cb54489c334b0072bf4fb726e