### PR TITLE
Assemble code update image method

### DIFF
--- a/yaml/xyz/openbmc_project/Software/LID.interface.yaml
+++ b/yaml/xyz/openbmc_project/Software/LID.interface.yaml
@@ -15,3 +15,7 @@ methods:
           - xyz.openbmc_project.Software.Version.Error.InvalidSignature
           - xyz.openbmc_project.Software.Version.Error.ExpiredAccessKey
           - xyz.openbmc_project.Software.Version.Error.Incompatible
+    - name: AssembleCodeUpdateImage
+      description: >
+          Assemble all the lid files received from host during inband code
+          update and create a tar ball image for code update.


### PR DESCRIPTION
This method is invoked during in-band code update path to assemble all the lids and create a code update image tar ball.