### PR TITLE
DHCPv6 Parameters for in network configuration

### DIFF
--- a/yaml/xyz/openbmc_project/Network/DHCPConfiguration.interface.yaml
+++ b/yaml/xyz/openbmc_project/Network/DHCPConfiguration.interface.yaml
@@ -28,3 +28,19 @@ properties:
       description: >
           if true then DHCP option 12 is enabled i.e machine`s hostname will be
           sent to the DHCP server.
+    - name: DNSv6Enabled
+      type: boolean
+      description: >
+          if true then the DNS servers received from the DHCPv6 server will be
+          used and take precedence over any statically configured ones.
+    - name: NTPv6Enabled
+      type: boolean
+      description: >
+          if true then the NTP servers received from the DHCPv6 server will be
+          used by systemd-timesyncd and take precedence over any statically
+          configured ones.
+    - name: HostNamev6Enabled
+      type: boolean
+      description: >
+          if true then the hostname received from the DHCPv6 server will be set
+          as the transient hostname of the system.


### PR DESCRIPTION
At present, DHCP parameters like DNSEnabled, NTPEnabled etc.
are shared between DHCPv4 and DHCPv6 in the network configuration.

This change is to enable the possibility to have separate
parameters for DHCPv4 and DHCPv6 in the network configuration to
be able to modify them individually.

upstream commit : https://gerrit.openbmc.org/c/openbmc/phosphor-dbus-interfaces/+/62912