### PR TITLE
Control.Power.Throttle: Add throttle Interface

### DIFF
--- a/gen/xyz/openbmc_project/Control/Power/Throttle/meson.build
+++ b/gen/xyz/openbmc_project/Control/Power/Throttle/meson.build
@@ -1,0 +1,15 @@
+# Generated file; do not modify.
+generated_sources += custom_target(
+    'xyz/openbmc_project/Control/Power/Throttle__cpp'.underscorify(),
+    input: [ '../../../../../../yaml/xyz/openbmc_project/Control/Power/Throttle.interface.yaml',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'cpp',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../../yaml',
+        'xyz/openbmc_project/Control/Power/Throttle',
+    ],
+)
+

--- a/gen/xyz/openbmc_project/Control/Power/meson.build
+++ b/gen/xyz/openbmc_project/Control/Power/meson.build
@@ -89,3 +89,18 @@ generated_others += custom_target(
     ],
 )
 
+subdir('Throttle')
+generated_others += custom_target(
+    'xyz/openbmc_project/Control/Power/Throttle__markdown'.underscorify(),
+    input: [ '../../../../../yaml/xyz/openbmc_project/Control/Power/Throttle.interface.yaml',  ],
+    output: [ 'Throttle.md' ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'markdown',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../yaml',
+        'xyz/openbmc_project/Control/Power/Throttle',
+    ],
+)
+

--- a/yaml/xyz/openbmc_project/Control/Power/Throttle.interface.yaml
+++ b/yaml/xyz/openbmc_project/Control/Power/Throttle.interface.yaml
@@ -1,0 +1,42 @@
+description: >
+    This interface provides information related to the throttle status of a
+    component.
+
+properties:
+    - name: ThrottleCauses
+      type: array[enum[self.ThrottleReasons]]
+      flags:
+          - readonly
+      description: >
+          This property shall contain the cause(s) of the component being
+          throttled when the Throttled property is true or an empty array if not
+          being throttled.
+    - name: Throttled
+      type: boolean
+      flags:
+          - readonly
+      default: false
+      description: >
+          This property shall indicate whether the component is throttled.
+
+enumerations:
+    - name: ThrottleReasons
+      description: >
+          The possible reasons a component could be throttled
+      values:
+          - name: ClockLimit
+            description: >
+                The cause of the component being throttled is a clock limit.
+          - name: ManagementDetectedFault
+            description: >
+                The cause of the component being throttled is a fault detected
+                by management hardware or firmware
+          - name: PowerLimit
+            decription: >
+                The cause of the component being throttled is a power limit.
+          - name: ThermalLimit
+            description: >
+                The cause of the component being throttled is a thermal limit.
+          - name: Unknown
+            description: >
+                The cause of the component being throttled is not known.


### PR DESCRIPTION
Define a throttle status interface. This allows users to determine if a component is being throttled and if so, what the causes are for the throttle.
This is part of the Redfish 2022.3 Schema.

Change-Id: I30e820993e3c225cd82bbd6c78e0a01f9a432282