### PR TITLE
Revert "power-recovery: add PowerRestoreDelay to RestorePolicy"

### DIFF
--- a/yaml/xyz/openbmc_project/Control/Power/RestorePolicy.interface.yaml
+++ b/yaml/xyz/openbmc_project/Control/Power/RestorePolicy.interface.yaml
@@ -9,12 +9,6 @@ properties:
       default: "Restore"
       description: >
           The policy to adopt after the BMC reset.
-    - name: PowerRestoreDelay
-      type: uint64
-      default: 0
-      description: >
-          The delay in microseconds before invoke power restore policy after
-          power applied. 0 - disable delay.
 
 enumerations:
     - name: Policy


### PR DESCRIPTION
This reverts commit 33c38cb266bf4fdc5a4aeb453d175763fd3bc9f8.

To keep forward compatibility, we can not allow new d-bus properties to be added to existing d-bus interfaces. The following issue describes the problem:
  openbmc/phosphor-settingsd#16

In summary, when a new property is added to an existing interface, any old properties do not have their value preserved upon a firmware update to a level with the new property. This causes serious issues within PSM as the one-time APR policy is utilized for inband code updates. This issue causes inband code updates to fail.

We will have to go back to the 1020-1040 solution which was to just hard code a 30s delay.