### PR TITLE
Add association between FabricAdapter and Slots

### DIFF
--- a/yaml/xyz/openbmc_project/Inventory/Item/FabricAdapter.interface.yaml
+++ b/yaml/xyz/openbmc_project/Inventory/Item/FabricAdapter.interface.yaml
@@ -2,3 +2,12 @@ description: >
     Implement to provide fabric adapter attributes. A physical fabric adapter
     capable of connecting to an interconnect fabric. Examples include but are
     not limited to Ethernet, NVMe over Fabrics, etc.
+
+associations:
+    - name: containing
+      description: >
+          Objects that implement FabricAdapter can optionally implement the
+          connecting association to provide links to one or more Slots
+      reverse_name: contained_by
+      required_endpoint_interfaces:
+          - xyz.openbmc_project.Inventory.Item.PCIeSlot

--- a/yaml/xyz/openbmc_project/Inventory/Item/README.md
+++ b/yaml/xyz/openbmc_project/Inventory/Item/README.md
@@ -24,3 +24,4 @@ Document ObjectMapper association forward and reverse names as follows:
 - led and item: `{identifying, identified_by}`
   `{fault_identifying, fault_identified_by}`
 - powerSupply and item: `{powering, powered_by}`
+- fabricAdapter and slot: `{containing, contained_by}`


### PR DESCRIPTION
On power systems - we have capability to enlarge the IO capacity of the server
 by attaching an external IO drawers. The external IO drawer extends the CEC PCIe
 fabric and spans out into multiple PCIe Slots. This commit adds a connection
 between FabricAdapter and extended PCIe Slots.

     - FabricAdapter may be "containing" one or more slots,
     - A slot may also be "contained_by" fabric adapter.
