### PR TITLE
1050: network/client: add TCP/UDP as Transport Protocol for Client

### DIFF
--- a/yaml/xyz/openbmc_project/Network/Client.interface.yaml
+++ b/yaml/xyz/openbmc_project/Network/Client.interface.yaml
@@ -16,3 +16,18 @@ properties:
           The value of this property is the network port number.
       errors:
           - xyz.openbmc_project.Common.Error.InternalFailure
+    - name: TransportProtocol
+      type: enum[self.TransportProtocol]
+      description: >
+          The value of this property is the network IP protocol.
+      default: TCP
+      errors:
+          - xyz.openbmc_project.Common.Error.InternalFailure
+
+enumerations:
+    - name: TransportProtocol
+      description: >
+          Possible IP protocol types.
+      values:
+          - name: TCP
+          - name: UDP


### PR DESCRIPTION
#### network/client: add TCP/UDP as Transport Protocol for Client
```
Add TCP/UDP transport protocol for Client interface to make it use for
different applications like rsyslog as example.

Change-Id: I08511a1a70396e1c6fb979febfa8fb7343235e9d
Signed-off-by: Ivan Mikhaylov <fr0st61te@gmail.com>
```