### PR TITLE
Add TPMDisable interface

### DIFF
--- a/yaml/xyz/openbmc_project/Control/TPM/Policy.interface.yaml
+++ b/yaml/xyz/openbmc_project/Control/TPM/Policy.interface.yaml
@@ -6,3 +6,7 @@ properties:
       type: boolean
       description: >
           Whether or not TPM is enabled.
+    - name: TPMDisable
+      type: boolean
+      description: >
+          Whether or not TPM is disable.


### PR DESCRIPTION
IBM has a new requirement to use a new sensor (disable_tpm_sensor) to
disable TPM.
This commit adds a new interface to the PDI repository for disabling
TPM called TPMDisable.

issue: https://github.com/ibm-openbmc/dev/issues/3634