### PR TITLE
Audit Log: Add xyz.openbmc_project.logging.AuditLog

### DIFF
--- a/gen/xyz/openbmc_project/Logging/AuditLog/meson.build
+++ b/gen/xyz/openbmc_project/Logging/AuditLog/meson.build
@@ -1,0 +1,15 @@
+# Generated file; do not modify.
+generated_sources += custom_target(
+    'xyz/openbmc_project/Logging/AuditLog__cpp'.underscorify(),
+    input: [ '../../../../../yaml/xyz/openbmc_project/Logging/AuditLog.interface.yaml',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'cpp',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../yaml',
+        'xyz/openbmc_project/Logging/AuditLog',
+    ],
+)
+

--- a/gen/xyz/openbmc_project/Logging/meson.build
+++ b/gen/xyz/openbmc_project/Logging/meson.build
@@ -1,4 +1,19 @@
 # Generated file; do not modify.
+subdir('AuditLog')
+generated_others += custom_target(
+    'xyz/openbmc_project/Logging/AuditLog__markdown'.underscorify(),
+    input: [ '../../../../yaml/xyz/openbmc_project/Logging/AuditLog.interface.yaml',  ],
+    output: [ 'AuditLog.md' ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'markdown',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../yaml',
+        'xyz/openbmc_project/Logging/AuditLog',
+    ],
+)
+
 subdir('Create')
 generated_others += custom_target(
     'xyz/openbmc_project/Logging/Create__markdown'.underscorify(),

--- a/yaml/xyz/openbmc_project/Logging/AuditLog.interface.yaml
+++ b/yaml/xyz/openbmc_project/Logging/AuditLog.interface.yaml
@@ -1,0 +1,45 @@
+description: >
+    This interface provides methods to extract the Linux audit logged events.
+methods:
+    - name: GetAuditLog
+      description: >
+          Parses all previously recorded log events into JSON format. Returns a
+          read-only file descriptor to the parsed file. Entries are sorted
+          oldest to newest.
+      returns:
+          - name: logFd
+            type: unixfd
+            description: >
+                The read-only file descriptor of the JSON formatted log events.
+      errors:
+          - xyz.openbmc_project.Common.Error.InternalFailure
+          - xyz.openbmc_project.Common.File.Error.Write
+          - xyz.openbmc_project.Common.File.Error.Open
+
+    - name: GetLatestEntries
+      description: >
+          Parses a subset of previously recorded log events into JSON format.
+          Returns a read-only file descriptor to the parsed file. Entries are
+          sorted newest to oldest.
+      parameters:
+          - name: maxCount
+            type: uint32
+            description:
+                Defines the maximum number of entries to return. Minimum value
+                is 1.
+      returns:
+          - name: logFd
+            type: unixfd
+            description: >
+                The read-only file descriptor of the JSON formatted log events.
+      errors:
+          - xyz.openbmc_project.Common.Error.InternalFailure
+          - xyz.openbmc_project.Common.File.Error.Write
+          - xyz.openbmc_project.Common.File.Error.Open
+
+paths:
+    - instance: /xyz/openbmc_project/logging/AuditLog
+      description: Expected path of the instance.
+service_names:
+    - default: xyz.openbmc_project.logging.AuditLog
+      description: Expected service name for the instance.


### PR DESCRIPTION
Scaled down implementation of upstream design still under review [1].
Upstream PDI changes also still under review [2].

Provides two methods:
  - GetAuditLog: Return limited number of entries sorted newest to
    oldest.
  - GetLatestEntries: Create downloadable file containing all entries
    sorted oldest to newest.

It is expected upstream that a full file download of the audit log
entries won't be accepted. Therefore the methods are split downstream to
simplify rework on upstream merge.

[1] https://gerrit.openbmc.org/c/openbmc/docs/+/63915
[2] https://gerrit.openbmc.org/c/openbmc/phosphor-dbus-interfaces/+/66616