### PR TITLE
Add Hostname property errors

### DIFF
--- a/yaml/xyz/openbmc_project/Network/SystemConfiguration.interface.yaml
+++ b/yaml/xyz/openbmc_project/Network/SystemConfiguration.interface.yaml
@@ -5,3 +5,5 @@ properties:
       type: string
       description: >
           The value of this property shall be host name of the system.
+      errors:
+          - xyz.openbmc_project.Common.Error.InvalidArgument


### PR DESCRIPTION
Hostname does not allow special characters while setting hostname this commit adds InvalidArgument error to handle invalid hostnames

Change-Id: I2ecc92637364baebe9e845bd22099fcb9744c2f4