### PR TITLE
Audit Log: Update GetLatestEntries description

### DIFF
--- a/yaml/xyz/openbmc_project/Logging/AuditLog.interface.yaml
+++ b/yaml/xyz/openbmc_project/Logging/AuditLog.interface.yaml
@@ -26,7 +26,7 @@ methods:
             type: uint32
             description:
                 Defines the maximum number of entries to return. Minimum value
-                is 1.
+                is 0.
       returns:
           - name: logFd
             type: unixfd


### PR DESCRIPTION
Implementation of method GetLatestEntries() in phosphor-logging resulted in allowing 0 to be specified for maxCount. Updating description to match the implementation.