### PR TITLE
1050: software: Add Minimum Version interface

### DIFF
--- a/gen/xyz/openbmc_project/Software/MinimumVersion/meson.build
+++ b/gen/xyz/openbmc_project/Software/MinimumVersion/meson.build
@@ -1,0 +1,15 @@
+# Generated file; do not modify.
+generated_sources += custom_target(
+    'xyz/openbmc_project/Software/MinimumVersion__cpp'.underscorify(),
+    input: [ '../../../../../yaml/xyz/openbmc_project/Software/MinimumVersion.interface.yaml',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'cpp',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../yaml',
+        'xyz/openbmc_project/Software/MinimumVersion',
+    ],
+)
+

--- a/gen/xyz/openbmc_project/Software/meson.build
+++ b/gen/xyz/openbmc_project/Software/meson.build
@@ -104,6 +104,21 @@ generated_others += custom_target(
     ],
 )
 
+subdir('MinimumVersion')
+generated_others += custom_target(
+    'xyz/openbmc_project/Software/MinimumVersion__markdown'.underscorify(),
+    input: [ '../../../../yaml/xyz/openbmc_project/Software/MinimumVersion.interface.yaml',  ],
+    output: [ 'MinimumVersion.md' ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'markdown',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../yaml',
+        'xyz/openbmc_project/Software/MinimumVersion',
+    ],
+)
+
 subdir('RedundancyPriority')
 generated_others += custom_target(
     'xyz/openbmc_project/Software/RedundancyPriority__markdown'.underscorify(),

--- a/yaml/xyz/openbmc_project/Software/MinimumVersion.interface.yaml
+++ b/yaml/xyz/openbmc_project/Software/MinimumVersion.interface.yaml
@@ -1,0 +1,9 @@
+description: >
+    The minimum version string for a xyz.openbmc_project.Software.Version.
+properties:
+    - name: MinimumVersion
+      type: string
+      description: >
+          The minimum software version that a component must have to operate.
+          The string format should be the same format used for the Version
+          property of the component.


### PR DESCRIPTION
The minimum version is an optional meson option (bmc-msl)[1] that prevents firmware updates to a level lower than the one set via this option.
The error logged is a Software Incompatible[2] error.

Add the minimum version as a property of a new interface. This will be populated by the code updater app. It can then be mapped to the SoftwareInventory LowestSupportedVersion Redfish property and be available to the user via Redfish and the GUI so that the user can know in advance which version of software is not supported on their system and avoid having to debug a code update failure after they attempt to install an incompatible version.

```
1: https://github.com/openbmc/phosphor-bmc-code-mgmt/blob/85c71a13e0938cc4d36caf6b8e735e9740b2e351/meson.options#L100
2: https://github.com/openbmc/phosphor-dbus-interfaces/blob/1c140b9766a15d1cbb8546fa02d5050d772a171d/yaml/xyz/openbmc_project/Software/Version.errors.yaml#L1
```

Change-Id: I1f6aacf8ad7fa63e58d832409698f4d923184ec2