### PR TITLE
Default value for LanesInUse set to MAXINT

### DIFF
--- a/yaml/xyz/openbmc_project/Inventory/Item/PCIeDevice.interface.yaml
+++ b/yaml/xyz/openbmc_project/Inventory/Item/PCIeDevice.interface.yaml
@@ -295,12 +295,13 @@ properties:
           The maximum number of PCIe lanes supported by the PCIe Device
 
     - name: LanesInUse
-      type: int64
-      default: -1
+      type: size
+      default: maxint
       description: >
-          The number of PCIe lanes in use by this device. Default value of -1 is
-          to accommodate the situation where value of this property cannot be
-          updated due to some unknown reason.
+          The number of PCIe lanes in use by this device. Deafult value of
+          maxint is to accommodate the situation where the value of this
+          property is not known due to some unknown reason, like hardware
+          failure or link down.
 
 associations:
     - name: upstream_pcie_slot


### PR DESCRIPTION
Changing the default value for property "LanesInUse" to accommodate situations where the reason behind failure to get the value is not known.
Some of the reason behind could be hardware failure or the link is down or power to the I/O slot may be off.


Change-Id: If3bccd89382934f4bcf7ccf16f8068153d113d2c