### PR TITLE
Cable, Chassis: Add associations documentation

### DIFF
--- a/yaml/xyz/openbmc_project/Inventory/Item/Cable.interface.yaml
+++ b/yaml/xyz/openbmc_project/Inventory/Item/Cable.interface.yaml
@@ -17,3 +17,19 @@ properties:
           user interfaces but this field should not be used for programmatic
           interrogation of a cable beyond ignoring the default value of the
           empty string.
+
+associations:
+    - name: downstream_chassis
+      description: >
+          Objects that implement Cable can optionally implement the
+          downstream_chassis association to provide a link to the chassis.
+      reverse_name: attached_cables
+      required_endpoint_interfaces:
+          - xyz.openbmc_project.Inventory.Item.Chassis
+    - name: upstream_chassis
+      description: >
+          Objects that implement Cable can optionally implement the
+          uptream_chassis association to provide a link to the chassis.
+      reverse_name: attached_cables
+      required_endpoint_interfaces:
+          - xyz.openbmc_project.Inventory.Item.Chassis

--- a/yaml/xyz/openbmc_project/Inventory/Item/Chassis.interface.yaml
+++ b/yaml/xyz/openbmc_project/Inventory/Item/Chassis.interface.yaml
@@ -59,3 +59,13 @@ associations:
       reverse_name: powering
       required_endpoint_interfaces:
           - xyz.openbmc_project.Inventory.Item.PowerSupply
+
+    - name: attached_cables
+      description: >
+          Objects that implement Chassis can optionally implement the
+          attached_cables association to provide a link to one or more cables.
+      reverse_names:
+          - downstream_chassis
+          - upstream_chassis
+      required_endpoint_interfaces:
+          - xyz.openbmc_project.Inventory.Item.Cable


### PR DESCRIPTION
This documentation is useful for user interface applications such as redfish to traverse to what they are connected to add associations.


Signed-off-by: Pavithra Barithaya <pavithrabarithaya07@gmail.com>