### PR TITLE
Cable, Connector: Add associations documentation

### DIFF
--- a/yaml/xyz/openbmc_project/Inventory/Item/Cable.interface.yaml
+++ b/yaml/xyz/openbmc_project/Inventory/Item/Cable.interface.yaml
@@ -33,3 +33,17 @@ associations:
       reverse_name: attached_cables
       required_endpoint_interfaces:
           - xyz.openbmc_project.Inventory.Item.Chassis
+    - name: upstream_connector
+      description: >
+          Objects that implement Cable can optionally implement the
+          upstream_connector association to provide a link to the connector.
+      reverse_name: attached_cables
+      required_endpoint_interfaces:
+          - xyz.openbmc_project.Inventory.Item.Connector
+    - name: downstream_connector
+      description: >
+          Objects that implement Cable can optionally implement the
+          downstream_connector association to provide a link to the connector.
+      reverse_name: attached_cables
+      required_endpoint_interfaces:
+          - xyz.openbmc_project.Inventory.Item.Connector

--- a/yaml/xyz/openbmc_project/Inventory/Item/Connector.interface.yaml
+++ b/yaml/xyz/openbmc_project/Inventory/Item/Connector.interface.yaml
@@ -1,3 +1,14 @@
 description: >
     Implement to provide connector attributes. A connector is typically an
     external port or a slot into which cables are plugged.
+
+associations:
+    - name: attached_cables
+      description: >
+          Objects that implement Connector can optionally implement the
+          attached_cables association to provide a link to the cable.
+      reverse_names:
+          - upstream_connector
+          - downstream_connector
+      required_endpoint_interfaces:
+          - xyz.openbmc_project.Inventory.Item.Cable


### PR DESCRIPTION
This documentation is useful for user interface applications such as redfish to traverse to what they are connected to add associations.

Change-Id: I71728d654c00ada25359c95de8b368e7a3c66283
Signed-off-by: Pavithra Barithaya <pavithrabarithaya07@gmail.com>
