### PR TITLE
1110:CI-only: create detect-secrets baseline file

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,410 @@
+{
+  "exclude": {
+    "files": "^.secrets.baseline$",
+    "lines": null
+  },
+  "generated_at": "2024-04-29T20:27:09Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "BoxDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "ghe_instance": "github.ibm.com",
+      "name": "GheDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "gen/xyz/openbmc_project/BIOSConfig/Password/meson.build": [
+      {
+        "hashed_secret": "1d550c76faec4793a038dad66bf0acbd56a78bd6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "287aa7ca33e2caf581397144b4d99ce2bac77a31",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 12,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "gen/xyz/openbmc_project/BIOSConfig/meson.build": [
+      {
+        "hashed_secret": "3b4d89f26594b275f7572bb14fed31ac4c9b5981",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 19,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "32cae99c56c08352b024c5143a153260ff0732de",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 34,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "287aa7ca33e2caf581397144b4d99ce2bac77a31",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 43,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "gen/xyz/openbmc_project/Chassis/Buttons/meson.build": [
+      {
+        "hashed_secret": "beaf12e8c0c79b996153a9a092be92cf3d91ca9c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 34,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e2e32c3eee55c7add306363fdc718825649e9701",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 49,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "gen/xyz/openbmc_project/Chassis/Control/meson.build": [
+      {
+        "hashed_secret": "80c36b2abfa06bf08cfcc8824e6cb06c7fc2147d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 4,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "gen/xyz/openbmc_project/Control/meson.build": [
+      {
+        "hashed_secret": "da76e96b446dd5cd2e7605d4f13ac74e64e17506",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 125,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "gen/xyz/openbmc_project/Debug/Pid/meson.build": [
+      {
+        "hashed_secret": "2a047bb010642adc3c0c183ac14c3ee12b5dcd2d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 4,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "gen/xyz/openbmc_project/Dump/Entry/meson.build": [
+      {
+        "hashed_secret": "fc6f4d36b80c3d54920e885311880b46b0b8c01a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 33,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "gen/xyz/openbmc_project/Inventory/Decorator/meson.build": [
+      {
+        "hashed_secret": "4369b59019efa5f62d3a5719df57d5f97f556cac",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 154,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "gen/xyz/openbmc_project/Inventory/Source/PLDM/meson.build": [
+      {
+        "hashed_secret": "ed066715a8cabc2f70d8cf1cbd12f7c8f8fecf9d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 4,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "37a9d713fcefe8778921871d4c427a601f5f6892",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 19,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "gen/xyz/openbmc_project/Logging/Syslog/Destination/Mail/meson.build": [
+      {
+        "hashed_secret": "3323ecc48acbbb5cd7092de250a6ddb41123f60c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 18,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "76f39990b87c80c1d44710398020878b1fd12c18",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 33,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "gen/xyz/openbmc_project/Network/DHCPConfiguration/meson.build": [
+      {
+        "hashed_secret": "9e7a358e66720aa777c00979fbd0f6d228ef2ebe",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d851dc305439492d378c4bd7fdbba6d04a7036cd",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 12,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "gen/xyz/openbmc_project/Network/meson.build": [
+      {
+        "hashed_secret": "749d2ad3b2fcb46239b98ec4afc1beae17d42341",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 19,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d851dc305439492d378c4bd7fdbba6d04a7036cd",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 28,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3e6b488f536ae81f62ca63d306e85e03e8e3d1e7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 110,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "gen/xyz/openbmc_project/PFR/meson.build": [
+      {
+        "hashed_secret": "b0493f4ddfa3fd8f0a95bbd0ec41199a5f1720fd",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 4,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "gen/xyz/openbmc_project/PLDM/Provider/Certs/Authority/CSR/meson.build": [
+      {
+        "hashed_secret": "d2450afd9d321f5d3ee26b2af1b97c09fac7d660",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6a94192043110ed2b45024e7c520f46bd0c834c3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 12,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "gen/xyz/openbmc_project/PLDM/Provider/Certs/Authority/meson.build": [
+      {
+        "hashed_secret": "8c3a14e0eb992744f256c371fbdf9fcf75fba687",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 4,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6a94192043110ed2b45024e7c520f46bd0c834c3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 13,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "gen/xyz/openbmc_project/PLDM/meson.build": [
+      {
+        "hashed_secret": "7c1559337ee017c391d9fdf71bd21a0d844829ca",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 35,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "gen/xyz/openbmc_project/Sensor/meson.build": [
+      {
+        "hashed_secret": "b8316d87f557089e77c311472270a9d42f26f148",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 64,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "gen/xyz/openbmc_project/Smbios/meson.build": [
+      {
+        "hashed_secret": "38803c78c53c42ca138338449014696f81507819",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 4,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "gen/xyz/openbmc_project/State/meson.build": [
+      {
+        "hashed_secret": "9d16c7d69920531d7952f7a0840173bed423ee22",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 97,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "gen/xyz/openbmc_project/User/meson.build": [
+      {
+        "hashed_secret": "46ad9d5d636b9d724a333f5a6342d933dcc102db",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 80,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "gen/xyz/openbmc_project/VirtualMedia/meson.build": [
+      {
+        "hashed_secret": "415062e8efc67b4d41a4071adfaa16b72ea0656a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 4,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "cb5504b6d9122ce2d2a770b3fad053699fa5827f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 34,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "05fdd4c42faad6eaecff6d5078c4ba7f20a6e226",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 64,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "yaml/xyz/openbmc_project/Certs/README.md": [
+      {
+        "hashed_secret": "6367c48dd193d56ea7b0baad25b19455e529f5ee",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 131,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ]
+  },
+  "version": "0.13.1+ibm.62.dss",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}


### PR DESCRIPTION
This creates a baseline file (and initial responses to any potential secrets found).

After this file is merged, all CI jobs after will run the detect-secrets tool against incoming commits to verify no potential secrets are being shared. If one is found, CI will fail until the .secrets.baseline is updated for the new issue.

See the following for more info:
  https://github.com/IBM/detect-secrets