### PR TITLE
Pulling OpenPOWER dump interfaces from master

### DIFF
--- a/yaml/com/ibm/Dump/Entry/Hardware.interface.yaml
+++ b/yaml/com/ibm/Dump/Entry/Hardware.interface.yaml
@@ -5,3 +5,18 @@ description: >
     registers, and it is used for debugging system checkstop. checkstop is the
     descriptive term for entire system termination by the hardware due to a
     detected error.
+
+properties:
+    - name: ErrorLogId
+      type: uint32
+      description: >
+          The id of the log associated with the action which triggered the dump.
+          This ID is a reference to an error log entry in the logging system.
+          The value should be a 32-bit unsigned integer.
+
+    - name: FailingUnitId
+      type: uint32
+      description: >
+          A unique id of the failing hardware unit which is causing the dump.
+          This ID could be used to identify the specific piece of hardware
+          within the system. The value should be a 32-bit unsigned integer.

--- a/yaml/com/ibm/Dump/Entry/Hostboot.interface.yaml
+++ b/yaml/com/ibm/Dump/Entry/Hostboot.interface.yaml
@@ -3,3 +3,11 @@ description: >
 
     Hostboot dump collects memory and hardware states in the case of a failure
     during hostboot booting phase.
+
+properties:
+    - name: ErrorLogId
+      type: uint32
+      description: >
+          The identifier of the log entry associated with the action which
+          triggered the dump. This is a 32-bit unsigned integer that links the
+          dump to a specific error log.

--- a/yaml/com/ibm/Dump/Entry/Resource.interface.yaml
+++ b/yaml/com/ibm/Dump/Entry/Resource.interface.yaml
@@ -18,10 +18,21 @@ properties:
       type: string
       description: >
           The resource selector for generating the dump.
-    - name: Password
+    - name: UserChallenge
       type: string
       description: >
-          The password required by host to validate the request.
+          On some host implementations a user-challenge need to be provided by
+          the user and it flows through BMC and up to the host as a part of the
+          dump request. Non-disruptive dumps consume significant host resources
+          and involve the collection of host memory data. To safeguard these
+          operations and ensure they are initiated only by authorized personnel,
+          the provided passphrase is employed. In some systems, an Access
+          Control List (ACL) file, provided through the Platform Level Data
+          Model (PLDM), is used. The host validates the provided user-challenge
+          against this ACL. If the user-challenge doesn't match any entry in the
+          ACL, the host will reject the dump request. This field is needed so
+          the host can check that only authorized users are allowed to perform
+          certain dump operations.
     - name: Token
       type: uint32
       description: >

--- a/yaml/com/ibm/Dump/Entry/Resource.interface.yaml
+++ b/yaml/com/ibm/Dump/Entry/Resource.interface.yaml
@@ -28,3 +28,36 @@ properties:
           A token exchanged with an external firmware subsystem when creating a
           dump outside of the BMC. This token can be used to identify the dump
           entry once the collection is completed.
+    - name: DumpRequestStatus
+      type: enum[self.HostResponse]
+      description: >
+          The host will send a response code for each request to create a
+          resource dump to indicate whether the request is successful or there
+          is an error.
+      default: Requested
+
+enumerations:
+    - name: HostResponse
+      description: >
+          These are the possible response codes from the host after sending a
+          resource dump request.
+      values:
+          - name: Requested
+            description: >
+                Requested for resource dump and awaiting the host response
+          - name: Success
+            description: >
+                Resource dump parameters and ACF data are successfully validated
+          - name: ACFFileInvalid
+            description: >
+                Invalid ACF file
+          - name: UserChallengeInvalid
+            description: >
+                User challenge provided is not valid
+          - name: PermissionDenied
+            descVSPtion: >
+                Caller does not have enough privileges to execute the requested
+                VSP string
+          - name: ResourceSelectorInvalid
+            description: >
+                Resource selector(VSP String) provided is not valid

--- a/yaml/com/ibm/Dump/Entry/SBE.interface.yaml
+++ b/yaml/com/ibm/Dump/Entry/SBE.interface.yaml
@@ -11,3 +11,18 @@ description: >
     packaged into the OpenPOWER dump format and which is called as SBE dump.
     There will be one instance of SBE on each processor. Implement this
     interface to add support for managing the SBE dump.
+
+properties:
+    - name: ErrorLogId
+      type: uint32
+      description: >
+          The id of the log associated with the action which triggered the dump.
+          This ID is a reference to an error log entry in the logging system.
+          The value should be a 32-bit unsigned integer.
+
+    - name: FailingUnitId
+      type: uint32
+      description: >
+          A unique id of the failing SBE which is causing the dump. This ID
+          could be used to identify the specific SBE  within the system. The
+          value should be a 32-bit unsigned integer.


### PR DESCRIPTION
Following commits are merged in master needed in 1110

51107: com-ibm-dump: Add response code to resource dump entry | https://gerrit.openbmc.org/c/openbmc/phosphor-dbus-interfaces/+/51107

71273: com.ibm: Add UserChallenge to replace password | https://gerrit.openbmc.org/c/openbmc/phosphor-dbus-interfaces/+/71273

71102: com.ibm: Add additional properties to hardware dump | https://gerrit.openbmc.org/c/openbmc/phosphor-dbus-interfaces/+/71102

71103: com.ibm: Add additional properties to SBE dump | https://gerrit.openbmc.org/c/openbmc/phosphor-dbus-interfaces/+/71103

71104: com.ibm: Add ErrorLogId to Hostboot dump | https://gerrit.openbmc.org/c/openbmc/phosphor-dbus-interfaces/+/71104