### PR TITLE
com.ibm: Add MemoryBufferSBE dump type

### DIFF
--- a/yaml/com/ibm/Dump/Create.interface.yaml
+++ b/yaml/com/ibm/Dump/Create.interface.yaml
@@ -50,5 +50,9 @@ enumerations:
                 host components. The content may vary accordingly.
           - name: "SBE"
             description: >
-                A dump collected from Self Boot Engine(SBE) when it encounters
-                an error and become unresponsive.
+                A dump collected from Self Boot Engine(SBE) on the processor
+                when it encounters an error and become unresponsive.
+          - name: "MemoryBufferSBE"
+            description: >
+                A dump collected from Self Boot Engine on the memory buffer when
+                it encounters critical failures or unresponsive.


### PR DESCRIPTION
The Self Boot Engine (SBE) is contained on certain memory buffers. When the SBE becomes unresponsive due to hardware or software issues, there's a need to collect diagnostic dumps from it. To address this need and differentiate such dumps from others, this commit adds the `MemoryBufferSBE` type to the com.ibm.Dump.Create interface. The structure and input to collect this dump is different from the processor SBE dump so making it a new dump type.

Change-Id: Ib07a0caa1521c5ae5f6e0682029b5c9e497152e8