### PR TITLE
PCIeLink and PCIeTopology DBus Interfaces

### DIFF
--- a/gen/com/ibm/Control/Host/PCIeLink/meson.build
+++ b/gen/com/ibm/Control/Host/PCIeLink/meson.build
@@ -1,0 +1,15 @@
+# Generated file; do not modify.
+generated_sources += custom_target(
+    'com/ibm/Control/Host/PCIeLink__cpp'.underscorify(),
+    input: [ '../../../../../../yaml/com/ibm/Control/Host/PCIeLink.interface.yaml',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'aserver.hpp', 'client.hpp',  ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'cpp',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../../yaml',
+        'com/ibm/Control/Host/PCIeLink',
+    ],
+)
+

--- a/gen/com/ibm/Control/Host/meson.build
+++ b/gen/com/ibm/Control/Host/meson.build
@@ -1,0 +1,16 @@
+# Generated file; do not modify.
+subdir('PCIeLink')
+generated_others += custom_target(
+    'com/ibm/Control/Host/PCIeLink__markdown'.underscorify(),
+    input: [ '../../../../../yaml/com/ibm/Control/Host/PCIeLink.interface.yaml',  ],
+    output: [ 'PCIeLink.md' ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'markdown',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../yaml',
+        'com/ibm/Control/Host/PCIeLink',
+    ],
+)
+

--- a/gen/com/ibm/Control/meson.build
+++ b/gen/com/ibm/Control/meson.build
@@ -1,0 +1,2 @@
+# Generated file; do not modify.
+subdir('Host')

--- a/gen/com/ibm/PLDM/PCIeTopology/meson.build
+++ b/gen/com/ibm/PLDM/PCIeTopology/meson.build
@@ -1,0 +1,15 @@
+# Generated file; do not modify.
+generated_sources += custom_target(
+    'com/ibm/PLDM/PCIeTopology__cpp'.underscorify(),
+    input: [ '../../../../../yaml/com/ibm/PLDM/PCIeTopology.interface.yaml',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'aserver.hpp', 'client.hpp',  ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'cpp',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../yaml',
+        'com/ibm/PLDM/PCIeTopology',
+    ],
+)
+

--- a/gen/com/ibm/PLDM/meson.build
+++ b/gen/com/ibm/PLDM/meson.build
@@ -1,0 +1,16 @@
+# Generated file; do not modify.
+subdir('PCIeTopology')
+generated_others += custom_target(
+    'com/ibm/PLDM/PCIeTopology__markdown'.underscorify(),
+    input: [ '../../../../yaml/com/ibm/PLDM/PCIeTopology.interface.yaml',  ],
+    output: [ 'PCIeTopology.md' ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'markdown',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../yaml',
+        'com/ibm/PLDM/PCIeTopology',
+    ],
+)
+

--- a/gen/com/ibm/meson.build
+++ b/gen/com/ibm/meson.build
@@ -1,8 +1,10 @@
 # Generated file; do not modify.
+subdir('Control')
 subdir('Dump')
 subdir('Hardware')
 subdir('License')
 subdir('Logging')
+subdir('PLDM')
 subdir('VPD')
 generated_others += custom_target(
     'com/ibm/VPD__markdown'.underscorify(),

--- a/yaml/com/ibm/Control/Host/PCIeLink.interface.yaml
+++ b/yaml/com/ibm/Control/Host/PCIeLink.interface.yaml
@@ -1,0 +1,9 @@
+description: >
+    PCIe Link Interface is used to reset the PCIe link.
+properties:
+    - name: linkReset
+      type: boolean
+      default: false
+      description: >
+          When set to true resets the PCIe Link. The service which monitors this
+          property moves it back to the default.

--- a/yaml/com/ibm/PLDM/PCIeTopology.interface.yaml
+++ b/yaml/com/ibm/PLDM/PCIeTopology.interface.yaml
@@ -1,0 +1,15 @@
+description: >
+    This interface is used by applications on bmc to request the PCIE topology
+    information.
+properties:
+    - name: PCIeTopologyRefresh
+      type: boolean
+      description: >
+          This property when set to 'true' refreshes the topology information.
+          The application which uses this should set it to 'false' when a
+          refresh occurs.
+    - name: SavePCIeTopologyInfo
+      type: boolean
+      description: >
+          This property when set to 'true' saves the topology information. The
+          information is saved in the form of a PEL(Error Log).

--- a/yaml/xyz/openbmc_project/Inventory/Item/Cable.interface.yaml
+++ b/yaml/xyz/openbmc_project/Inventory/Item/Cable.interface.yaml
@@ -18,6 +18,28 @@ properties:
           interrogation of a cable beyond ignoring the default value of the
           empty string.
 
+    - name: CableStatus
+      type: enum[self.Status]
+      default: "Unknown"
+      description: >
+          The status of the cable. The default status is unknown.
+enumerations:
+    - name: Status
+      description: >
+          Possible cable status
+      values:
+          - name: "Inactive"
+            description: >
+                Cable is inactive.
+          - name: "Running"
+            description: >
+                Cable is running.
+          - name: "PoweredOff"
+            description: >
+                Cable is powered off.
+          - name: "Unknown"
+            description: >
+                Cable status is unknown.
 associations:
     - name: downstream_chassis
       description: >

--- a/yaml/xyz/openbmc_project/Inventory/Item/PCIeSlot.interface.yaml
+++ b/yaml/xyz/openbmc_project/Inventory/Item/PCIeSlot.interface.yaml
@@ -25,6 +25,17 @@ properties:
       description: >
           Whether this PCIe slot supports hotplug
 
+    - name: LinkStatus
+      type: enum[self.Status]
+      default: "Unknown"
+      description: >
+          Status of PCIe bus linked to the slot.
+
+    - name: BusId
+      type: size
+      description: >
+          Identifier to detect the PCIe bus linked to the slot.
+
 enumerations:
     - name: Generations
       description: >
@@ -97,6 +108,30 @@ enumerations:
           - name: "Unknown"
             description: >
                 Type of the PCIe slot is unknown
+
+    - name: Status
+      description: >
+          Possible link status
+      values:
+          - name: "Operational"
+            description: >
+                Link is operational
+          - name: "Degraded"
+            description: >
+                Link is degraded
+          - name: "Failed"
+            description: >
+                Link failed
+          - name: "Open"
+            description: >
+                Link is open
+
+          - name: "Inactive"
+            description: >
+                Link is inactive
+          - name: "Unknown"
+            description: >
+                Link status is unknown
 
 association:
     name: connected_to


### PR DESCRIPTION
This commit
- adds support for com.ibm.Control.Host.PcieLink interface that hosts a new boolean property called linkReset.
- defines PCIeTopology DBus interface. This interface is used by applications on bmc to
request the pcie topology information.
- defines new enum property called CableStatus under the Cable Interface.
This also adds the downstream chassis_associations and connector associations.
- changes the type and default value for property LanesInUse in order to accommodate the situation where reason of not getting this value is unknown.
- defines property to hold PCIe link status value for a given PCIe slot.
- adds property BusId to PCIeSlot interfce, the property will be required to detect the bus on which the slot resides.