### PR TITLE
StaticGateway: Remove PrefixLength property

### DIFF
--- a/yaml/xyz/openbmc_project/Network/StaticGateway.interface.yaml
+++ b/yaml/xyz/openbmc_project/Network/StaticGateway.interface.yaml
@@ -10,13 +10,6 @@ properties:
       errors:
           - xyz.openbmc_project.Common.Error.NotAllowed
 
-    - name: PrefixLength
-      type: size
-      description: >
-          This is the number of network bits in the address.
-      errors:
-          - xyz.openbmc_project.Common.Error.NotAllowed
-
     - name: ProtocolType
       type: enum[xyz.openbmc_project.Network.IP.Protocol]
       description: >

--- a/yaml/xyz/openbmc_project/Network/StaticGateway/Create.interface.yaml
+++ b/yaml/xyz/openbmc_project/Network/StaticGateway/Create.interface.yaml
@@ -8,10 +8,6 @@ methods:
             type: string
             description: >
                 Static gateway address
-          - name: PrefixLength
-            type: size
-            description: >
-                Number of network bits in the address
           - name: ProtocolType
             type: enum[xyz.openbmc_project.Network.IP.Protocol]
             description: >


### PR DESCRIPTION
Static gateway configuration does not require prefix length property

This commit removes PrefixLength property from static gateway D-bus method and interface.

Change-Id: Ic21bfdc457bfba2bfd9993bb786c084641e8ffe3