### PR TITLE
com.ibm: Add DI property to ipzvpd VINI interface

### DIFF
--- a/gen/org/open_power/HardwareIsolation/Create/meson.build
+++ b/gen/org/open_power/HardwareIsolation/Create/meson.build
@@ -2,7 +2,7 @@
 generated_sources += custom_target(
     'org/open_power/HardwareIsolation/Create__cpp'.underscorify(),
     input: [ '../../../../../yaml/org/open_power/HardwareIsolation/Create.interface.yaml',  ],
-    output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'aserver.hpp', 'client.hpp',  ],
     depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',

--- a/yaml/com/ibm/ipzvpd/VINI.interface.yaml
+++ b/yaml/com/ibm/ipzvpd/VINI.interface.yaml
@@ -77,5 +77,9 @@ properties:
       type: array[byte]
       description: >
           VN keyword.
+    - name: DI
+      type: array[byte]
+      description: >
+          DI keyword. Contains DRAM manufacturer ID.
 
 # vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/yaml/xyz/openbmc_project/Logging/Event.interface.yaml
+++ b/yaml/xyz/openbmc_project/Logging/Event.interface.yaml
@@ -39,18 +39,18 @@ enumerations:
       description: >
           Possiable severity levels for the event.
       values:
-        - name: Unknown
-          description: >
-              The event severity is unknown.
-        - name: Ok
-          description: >
-              The event severity is normal and attention is not required.
-        - name: Critical
-          description: >
-              The event severity is critical and requires immediate attention.
-        - name: Warning
-          description: >
-              The event severity is warning and requires attention.
+          - name: Unknown
+            description: >
+                The event severity is unknown.
+          - name: Ok
+            description: >
+                The event severity is normal and attention is not required.
+          - name: Critical
+            description: >
+                The event severity is critical and requires immediate attention.
+          - name: Warning
+            description: >
+                The event severity is warning and requires attention.
 
 service_names:
     - default: xyz.openbmc_project.Logging


### PR DESCRIPTION
The property DI reflects keyword required to hold DRAM manufacturer ID in case of DIMMs.

Change-Id: I197d13a006ad9bad5225d951b730cca57c263749