### PR TITLE
com.ibm: Add DI property to ipzvpd VINI interface

### DIFF
--- a/yaml/com/ibm/ipzvpd/README.md
+++ b/yaml/com/ibm/ipzvpd/README.md
@@ -5,12 +5,12 @@ consists of keywords that are stored as key-value pairs (Keyword name and its
 value). Keywords are grouped into records, usually with similar function grouped
 into a single record.
 
-The [OpenPower VPD] [1] format is quite similar to the IPZ format and describes
-the record-keyword structure.
+The [OpenPower VPD] [1] format is quite similar to the IPZ format and describes the
+record-keyword structure.
 
-Also refer to the [VPD Collection design document] [2] that describes how the
-VPD collection application on the BMC will parse and publish the VPD data for
-IBM Power systems on D-Bus.
+Also refer to the [VPD Collection design document] [2] that describes how the VPD
+collection application on the BMC will parse and publish the VPD data for IBM Power
+systems on D-Bus.
 
 The D-Bus interfaces defined here describe how IPZ VPD will be made available on
 D-Bus. Each YAML here represents a record in the IPZ VPD and keywords that

--- a/yaml/com/ibm/ipzvpd/VINI.interface.yaml
+++ b/yaml/com/ibm/ipzvpd/VINI.interface.yaml
@@ -77,5 +77,9 @@ properties:
       type: array[byte]
       description: >
           VN keyword.
+    - name: DI
+      type: array[byte]
+      description: >
+          DI keyword. Contains DRAM manufacturer ID.
 
 # vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/yaml/xyz/openbmc_project/Software/README.md
+++ b/yaml/xyz/openbmc_project/Software/README.md
@@ -27,11 +27,11 @@ Images maintained in the file system would be presented as a corresponding
 `xyz.openbmc_project.Common.FilePath` interface would be provided to specify the
 location of the image.
 
-It is assumed that the _ImageManager_ has [at least] a bare minimum amount of
-parsing knowledge, perhaps due to a common image format, to allow it to populate
-all of the properties of `xyz.openbmc_project.Software.Version` and
-`xyz.openbmc_project.Inventory.Decorator.Compatible`. _ItemUpdater_(s) will
-likely listen for standard D-Bus signals to identify new images being created.
+It is assumed that the _ImageManager_ has [at least] a bare minimum amount of parsing
+knowledge, perhaps due to a common image format, to allow it to populate all of the
+properties of `xyz.openbmc_project.Software.Version` and `xyz.openbmc_project.Inventory.Decorator.Compatible`.
+_ItemUpdater_(s) will likely listen for standard D-Bus signals to identify new images
+being created.
 
 ### ItemUpdater
 


### PR DESCRIPTION
The property DI reflects keyword required to hold DRAM manufacturer ID in case of DIMMs.

Change-Id: I197d13a006ad9bad5225d951b730cca57c263749