### PR TITLE
Adding chapdata properties support for fileio operation

### DIFF
--- a/gen/com/ibm/PLDM/ChapData/meson.build
+++ b/gen/com/ibm/PLDM/ChapData/meson.build
@@ -1,0 +1,15 @@
+# Generated file; do not modify.
+generated_sources += custom_target(
+    'com/ibm/PLDM/ChapData__cpp'.underscorify(),
+    input: [ '../../../../../yaml/com/ibm/PLDM/ChapData.interface.yaml',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'aserver.hpp', 'client.hpp',  ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'cpp',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../yaml',
+        'com/ibm/PLDM/ChapData',
+    ],
+)
+

--- a/gen/com/ibm/PLDM/meson.build
+++ b/gen/com/ibm/PLDM/meson.build
@@ -1,0 +1,16 @@
+# Generated file; do not modify.
+subdir('ChapData')
+generated_others += custom_target(
+    'com/ibm/PLDM/ChapData__markdown'.underscorify(),
+    input: [ '../../../../yaml/com/ibm/PLDM/ChapData.interface.yaml',  ],
+    output: [ 'ChapData.md' ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'markdown',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../yaml',
+        'com/ibm/PLDM/ChapData',
+    ],
+)
+

--- a/gen/com/ibm/meson.build
+++ b/gen/com/ibm/meson.build
@@ -3,6 +3,7 @@ subdir('Dump')
 subdir('Hardware')
 subdir('License')
 subdir('Logging')
+subdir('PLDM')
 subdir('VPD')
 generated_others += custom_target(
     'com/ibm/VPD__markdown'.underscorify(),

--- a/yaml/com/ibm/PLDM/ChapData.interface.yaml
+++ b/yaml/com/ibm/PLDM/ChapData.interface.yaml
@@ -1,0 +1,18 @@
+description: >
+    Implement this interface to pass Chap data details to Host which are set by
+    the user.
+
+    com.ibm.PLDM.ChapData object implements this interface.
+
+properties:
+    - name: ChapName
+      type: string
+      description: >
+          ChapName is a user selected name associated with each of the chap
+          secret user challenge.
+
+    - name: ChapSecret
+      type: string
+      description: >
+          ChapSecret is an encrypted secret user challenge transferred to the
+          Host for the respective ChapName.


### PR DESCRIPTION
Adding ChapName and ChapSecret properties in PLDM to transfer ChapData information between PLDM and Host as part of 1KW line item. This Chap data is a information of encrypted password which would be set by GUI into Dbus properties via redfish.
PLDM is hosting these properties into the Dbus path and when GUI changes properties values then PLDM will collect that data and sends that data to Host using FILEIO operation.

>chap properties are seen at Dbus level like this:
`root@rainxxxbmc:~# busctl introspect  xyz.openbmc_project.PLDM /xyz/openbmc_project/pldm
NAME                                       TYPE      SIGNATURE RESULT/VALUE                             FLAGS
com.ibm.PLDM.ChapData                      interface -         -                                        -
.ChapName                                  property  s         "kk"                                     emits-change writable
.ChapSecret                                property  s         "123458"                                 emits-change writable`