### PR TITLE
State: Add BMC redundancy interface

### DIFF
--- a/gen/xyz/openbmc_project/State/BMC/Redundancy/meson.build
+++ b/gen/xyz/openbmc_project/State/BMC/Redundancy/meson.build
@@ -1,0 +1,15 @@
+# Generated file; do not modify.
+generated_sources += custom_target(
+    'xyz/openbmc_project/State/BMC/Redundancy__cpp'.underscorify(),
+    input: [ '../../../../../../yaml/xyz/openbmc_project/State/BMC/Redundancy.interface.yaml',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'aserver.hpp', 'client.hpp',  ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'cpp',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../../yaml',
+        'xyz/openbmc_project/State/BMC/Redundancy',
+    ],
+)
+

--- a/gen/xyz/openbmc_project/State/BMC/meson.build
+++ b/gen/xyz/openbmc_project/State/BMC/meson.build
@@ -13,3 +13,18 @@ generated_sources += custom_target(
     ],
 )
 
+subdir('Redundancy')
+generated_others += custom_target(
+    'xyz/openbmc_project/State/BMC/Redundancy__markdown'.underscorify(),
+    input: [ '../../../../../yaml/xyz/openbmc_project/State/BMC/Redundancy.interface.yaml',  ],
+    output: [ 'Redundancy.md' ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'markdown',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../yaml',
+        'xyz/openbmc_project/State/BMC/Redundancy',
+    ],
+)
+

--- a/yaml/xyz/openbmc_project/State/BMC/Redundancy.interface.yaml
+++ b/yaml/xyz/openbmc_project/State/BMC/Redundancy.interface.yaml
@@ -1,0 +1,50 @@
+description: >
+    This interface holds redundant BMC related information.  There would be
+    instance of this interface on each BMC.
+
+properties:
+    - name: Role
+      type: enum[self.Role]
+      flags:
+          - readonly
+      default: Unknown
+      description: >
+          The redundancy role of the BMC.
+    - name: RedundancyEnabled
+      type: boolean
+      flags:
+          - readonly
+      default: false
+      description: >
+          If redundancy is currently enabled.  In general, this means that the
+          BMCs are configured as active and passive and that the passive is able
+          to be failed over to.
+
+enumerations:
+    - name: Role
+      description: >
+          Defines the redundancy role of the BMC.
+      values:
+          - name: Unknown
+            description: >
+                The role is unknown.
+          - name: Active
+            description: >
+                The role is for the active BMC.  This is the fully functioning
+                BMC and the main point of contact for external users.
+          - name: Passive
+            description: >
+                The role is for the passive BMC, which is the opposite of the
+                active BMC.  It may not have all services running, and would
+                require a failover to become active.
+
+signals:
+    - name: Heartbeat
+      description: >
+          This signal is to be emitted periodically from the management daemon
+          to let the sibling BMC interface daemon know it is alive.
+
+paths:
+    - instance: /xyz/openbmc_project/state/bmc0
+      description: >
+          The BMC redundancy path.


### PR DESCRIPTION
Define an interface in support of redundant BMC functionality as mentioned in the design doc
https://gerrit.openbmc.org/c/openbmc/docs/+/70233.  To start with, it defines the Role and RedundancyEnabled properties.

With this usage one BMC is considered the active BMC, and the other is the passive.  There will be a new application running on each BMC that hosts this interface.

This implementation is not related to the one that uses the xyz.openbmc_project.State.BMCRedundancy interface, of which there doesn't appear to be any upstream uses of.

Change-Id: I6415175bbee03f6c07b14e1db1ee0082bd1724ed