### PR TITLE
State: Add Redundant BMC Sibling interface

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-09-13T04:50:26Z",
+  "generated_at": "2024-09-17T18:14:09Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -341,6 +341,16 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 4,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "gen/xyz/openbmc_project/State/BMC/Redundancy/meson.build": [
+      {
+        "hashed_secret": "5c7e6b242439fcc19500e807c5d9a411028ee7d2",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 18,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }

--- a/gen/xyz/openbmc_project/State/BMC/Redundancy/Sibling/meson.build
+++ b/gen/xyz/openbmc_project/State/BMC/Redundancy/Sibling/meson.build
@@ -1,0 +1,15 @@
+# Generated file; do not modify.
+generated_sources += custom_target(
+    'xyz/openbmc_project/State/BMC/Redundancy/Sibling__cpp'.underscorify(),
+    input: [ '../../../../../../../yaml/xyz/openbmc_project/State/BMC/Redundancy/Sibling.interface.yaml',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'aserver.hpp', 'client.hpp',  ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'cpp',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../../../yaml',
+        'xyz/openbmc_project/State/BMC/Redundancy/Sibling',
+    ],
+)
+

--- a/gen/xyz/openbmc_project/State/BMC/Redundancy/meson.build
+++ b/gen/xyz/openbmc_project/State/BMC/Redundancy/meson.build
@@ -13,3 +13,18 @@ generated_sources += custom_target(
     ],
 )
 
+subdir('Sibling')
+generated_others += custom_target(
+    'xyz/openbmc_project/State/BMC/Redundancy/Sibling__markdown'.underscorify(),
+    input: [ '../../../../../../yaml/xyz/openbmc_project/State/BMC/Redundancy/Sibling.interface.yaml',  ],
+    output: [ 'Sibling.md' ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'markdown',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../../yaml',
+        'xyz/openbmc_project/State/BMC/Redundancy/Sibling',
+    ],
+)
+

--- a/yaml/xyz/openbmc_project/State/BMC/Redundancy/Sibling.interface.yaml
+++ b/yaml/xyz/openbmc_project/State/BMC/Redundancy/Sibling.interface.yaml
@@ -1,0 +1,92 @@
+description: >
+    This interface describes the API to read information from a sibling BMC in a
+    redundant configuration.
+
+properties:
+    - name: BMCPosition
+      type: size
+      default: 0
+      flags:
+          - readonly
+      description: >
+          The position the sibling BMC thinks it is.  Important on systems where
+          there is an opportunity to plug hardware or cables in wrong.
+
+    - name: FWVersion
+      type: string
+      flags:
+          - readonly
+      description: >
+          The version of the firmware that the sibling is running.
+
+    - name: Provisioned
+      type: boolean
+      default: false
+      flags:
+          - readonly
+      description: >
+          If the sibling has been provisioned.
+
+    - name: RedundancyEnabled
+      type: boolean
+      default: false
+      flags:
+          - readonly
+      description: >
+          If the sibling BMC has redundancy enabled.  This may only make sense
+          if the sibling has the active role.
+
+    - name: FailoversPaused
+      type: boolean
+      default: false
+      flags:
+          - readonly
+      description: >
+          If the sibling has failovers paused.  Redundancy is still considered
+          enabled (syncs are happening). This may need to happen during certain
+          events, for example during a code update. This may only make sense if
+          the sibling has the active role.
+
+    - name: BMCState
+      type: enum[xyz.openbmc_project.State.BMC.BMCState]
+      default: NotReady
+      flags:
+          - readonly
+      description: >
+          The BMC state of the sibling.
+
+    - name: Role
+      type: enum[xyz.openbmc_project.State.BMC.Redundancy.Role]
+      default: Unknown
+      flags:
+          - readonly
+      description: >
+          The redundancy role of the sibling.
+
+    - name: CommunicationOK
+      type: boolean
+      default: false
+      flags:
+          - readonly
+      description: >
+          If the sibling BMC thinks it has good communication with this BMC.
+          It's possible the system is wired such that one cannot imply that the
+          sibling BMC can also read from this BMC just because this BMC can read
+          from the sibling.
+
+    - name: Heartbeat
+      type: boolean
+      default: false
+      flags:
+          - readonly
+      description: >
+          If the redundancy management software running on the sibling BMC is
+          providing a continous heartbeat indicating that it is up and running.
+
+paths:
+    - namespace: /xyz/openbmc_project/state
+      segments:
+          - name: BMC
+            description: >
+                The object representing the first sibling is at bmc1.
+            value: bmc1


### PR DESCRIPTION
The redundant BMC design at
https://gerrit.openbmc.org/c/openbmc/docs/+/70233 describes creating two new applications: one to do the management, and another to provide an API that the first application uses to get information from the sibling BMC.  This commit is the D-Bus interface of the latter daemon.

Change-Id: I0cd3d2f78ffbfc2998e7c8fcace1723954df3e98