### PR TITLE
Add support for spare core

### DIFF
--- a/yaml/xyz/openbmc_project/HardwareIsolation/Entry.interface.yaml
+++ b/yaml/xyz/openbmc_project/HardwareIsolation/Entry.interface.yaml
@@ -47,3 +47,6 @@ enumerations:
             description: >
                 A user attempted to isolate hardware to proceed with the host to
                 boot.
+          - name: Spare
+            description: >
+                The isolated hardware is a spare core.


### PR DESCRIPTION
When a core is guarded as spare, the severity needs to be returned as spare. Adding the new severity type to address the requirement.

Test output
```
    Hardware_isolation entries response:
    {
      "@odata.id": "/redfish/v1/Systems/system/LogServices/HardwareIsolation/Entries/1",
      "@odata.type": "#LogEntry.v1_9_0.LogEntry",
      "Created": "2024-08-25T12:34:35+00:00",
      "EntryType": "Event",
      "Id": "1",
      "Links": {
        "OriginOfCondition": {
          "@odata.id": "/redfish/v1/Systems/system/Processors/dcm0-cpu1/SubProcessors/core2"
        }
      },
      "Message": "core2",
      "Name": "Hardware Isolation Entry",
      "Severity": "Spare"
    }

    subprocessor response
    {
      "/Status/Conditions/0/Severity": "OK",
      "@odata.id": "/redfish/v1/Systems/system/Processors/dcm0-cpu1/SubProcessors/core2",
      "@odata.type": "#Processor.v1_18_0.Processor",
      "Enabled": false,
      "Id": "core2",
      "Name": "core2",
      "Status": {
        "Conditions": [
          {
            "Message": "The reason for the resource isolation: Spare",
            "MessageArgs": [
              "Spare"
            ],
            "MessageId": "OpenBMC.0.2.HardwareIsolationReason",
            "Timestamp": "2024-08-25T13:46:06+00:00"
          }
        ],
        "Health": "Critical",
        "State": "Disabled"
      }
    }
```