### PR TITLE
PCIeLink and PCIeTopology DBus Interfaces

### DIFF
--- a/gen/com/ibm/Control/Host/PCIeLink/meson.build
+++ b/gen/com/ibm/Control/Host/PCIeLink/meson.build
@@ -1,0 +1,15 @@
+# Generated file; do not modify.
+generated_sources += custom_target(
+    'com/ibm/Control/Host/PCIeLink__cpp'.underscorify(),
+    input: [ '../../../../../../yaml/com/ibm/Control/Host/PCIeLink.interface.yaml',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'aserver.hpp', 'client.hpp',  ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'cpp',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../../yaml',
+        'com/ibm/Control/Host/PCIeLink',
+    ],
+)
+

--- a/gen/com/ibm/Control/Host/meson.build
+++ b/gen/com/ibm/Control/Host/meson.build
@@ -1,0 +1,16 @@
+# Generated file; do not modify.
+subdir('PCIeLink')
+generated_others += custom_target(
+    'com/ibm/Control/Host/PCIeLink__markdown'.underscorify(),
+    input: [ '../../../../../yaml/com/ibm/Control/Host/PCIeLink.interface.yaml',  ],
+    output: [ 'PCIeLink.md' ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'markdown',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../yaml',
+        'com/ibm/Control/Host/PCIeLink',
+    ],
+)
+

--- a/gen/com/ibm/Control/meson.build
+++ b/gen/com/ibm/Control/meson.build
@@ -1,0 +1,2 @@
+# Generated file; do not modify.
+subdir('Host')

--- a/gen/com/ibm/PLDM/PCIeTopology/meson.build
+++ b/gen/com/ibm/PLDM/PCIeTopology/meson.build
@@ -1,0 +1,15 @@
+# Generated file; do not modify.
+generated_sources += custom_target(
+    'com/ibm/PLDM/PCIeTopology__cpp'.underscorify(),
+    input: [ '../../../../../yaml/com/ibm/PLDM/PCIeTopology.interface.yaml',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'aserver.hpp', 'client.hpp',  ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'cpp',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../yaml',
+        'com/ibm/PLDM/PCIeTopology',
+    ],
+)
+

--- a/gen/com/ibm/PLDM/meson.build
+++ b/gen/com/ibm/PLDM/meson.build
@@ -14,3 +14,18 @@ generated_others += custom_target(
     ],
 )
 
+subdir('PCIeTopology')
+generated_others += custom_target(
+    'com/ibm/PLDM/PCIeTopology__markdown'.underscorify(),
+    input: [ '../../../../yaml/com/ibm/PLDM/PCIeTopology.interface.yaml',  ],
+    output: [ 'PCIeTopology.md' ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'markdown',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../yaml',
+        'com/ibm/PLDM/PCIeTopology',
+    ],
+)
+

--- a/gen/com/ibm/meson.build
+++ b/gen/com/ibm/meson.build
@@ -1,4 +1,5 @@
 # Generated file; do not modify.
+subdir('Control')
 subdir('Dump')
 subdir('Hardware')
 subdir('License')

--- a/yaml/com/ibm/Control/Host/PCIeLink.interface.yaml
+++ b/yaml/com/ibm/Control/Host/PCIeLink.interface.yaml
@@ -1,0 +1,9 @@
+description: >
+    PCIe Link Interface is used to reset the PCIe link.
+properties:
+    - name: linkReset
+      type: boolean
+      default: false
+      description: >
+          When set to true resets the PCIe Link. The service which monitors this
+          property moves it back to the default.

--- a/yaml/com/ibm/PLDM/PCIeTopology.interface.yaml
+++ b/yaml/com/ibm/PLDM/PCIeTopology.interface.yaml
@@ -1,0 +1,15 @@
+description: >
+    This interface is used by applications on bmc to request the PCIE topology
+    information.
+properties:
+    - name: PCIeTopologyRefresh
+      type: boolean
+      description: >
+          This property when set to 'true' refreshes the topology information.
+          The application which uses this should set it to 'false' when a
+          refresh occurs.
+    - name: SavePCIeTopologyInfo
+      type: boolean
+      description: >
+          This property when set to 'true' saves the topology information. The
+          information is saved in the form of a PEL(Error Log).


### PR DESCRIPTION
This commit
- adds support for com.ibm.Control.Host.PCIeLink interface that hosts a new boolean property called linkReset.
- defines PCIeTopology DBus interface. This interface is used by applications on bmc to
request the pcie topology information.

Change-Id: Ic12ca0b1b1a799046b8b66323e607469a51e3578
Signed-off-by: Pavithra Barithaya <pavithrabarithaya07@gmail.com>