### PR TITLE
HardwareIsolation: Implement new guard type: Spare

### DIFF
--- a/yaml/xyz/openbmc_project/HardwareIsolation/Entry.interface.yaml
+++ b/yaml/xyz/openbmc_project/HardwareIsolation/Entry.interface.yaml
@@ -47,3 +47,9 @@ enumerations:
             description: >
                 A user attempted to isolate hardware to proceed with the host to
                 boot.
+          - name: Spare
+            description: >
+                This hardware is isolated and a extra spare hardware available
+                is deployed. The system configuration benefits will be met.
+                There will be no impact on the performance due to this
+                isolation.


### PR DESCRIPTION
The system may have additional spare hardware that is not currently configured.

When a configured component becomes isolated due to an error, an available spare can be activated without affecting user experience. This helps maintain the integrity of the system configuration.

This commit introduces a new enum to indicate that the hardware is currently isolated, but a spare has been activated, allowing the user to disregard this isolation.