### PR TITLE
1110: Logging: Entry: Add errors to Resolved Property

### DIFF
--- a/yaml/xyz/openbmc_project/Logging/Entry.interface.yaml
+++ b/yaml/xyz/openbmc_project/Logging/Entry.interface.yaml
@@ -45,6 +45,8 @@ properties:
           this error log has been resolved. This will start out 'false' by
           default. Setting this to 'true' will NOT result in the error log being
           deleted.
+      errors:
+          - xyz.openbmc_project.Common.Error.Unavailable
     - name: ServiceProviderNotify
       type: enum[self.Notify]
       default: NotSupported


### PR DESCRIPTION
#### Logging: Entry: Add errors to Resolved Property
```
Add the error 'xyz.openbmc_project.Common.Error.Unavailable' to the
'Resolved' property of the Entry interface.

This change helps in notifying the users when the attempt to set the
Resolved property is prevented until the corresponding error log is
addressed.

For example, if the error log is associated with a HardwareIsolation
entry (which indicates the faulty hardware) and has not been resolved
yet; in this case, we need to prevent setting the 'Resolved' flag.

Change-Id: I64da52e572ba33f888d33039ac604c57b86d84de
Signed-off-by: Arya K Padman <aryakpadman@gmail.com>
```