### PR TITLE
1110: Dual-boot: BIOS attribute for choosing OS

### DIFF
--- a/gen/com/ibm/Host/Target/meson.build
+++ b/gen/com/ibm/Host/Target/meson.build
@@ -1,0 +1,15 @@
+# Generated file; do not modify.
+generated_sources += custom_target(
+    'com/ibm/Host/Target__cpp'.underscorify(),
+    input: [ '../../../../../yaml/com/ibm/Host/Target.interface.yaml',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'aserver.hpp', 'client.hpp',  ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'cpp',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../yaml',
+        'com/ibm/Host/Target',
+    ],
+)
+

--- a/gen/com/ibm/Host/meson.build
+++ b/gen/com/ibm/Host/meson.build
@@ -1,0 +1,16 @@
+# Generated file; do not modify.
+subdir('Target')
+generated_others += custom_target(
+    'com/ibm/Host/Target__markdown'.underscorify(),
+    input: [ '../../../../yaml/com/ibm/Host/Target.interface.yaml',  ],
+    output: [ 'Target.md' ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'markdown',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../yaml',
+        'com/ibm/Host/Target',
+    ],
+)
+

--- a/gen/com/ibm/meson.build
+++ b/gen/com/ibm/meson.build
@@ -2,6 +2,7 @@
 subdir('Control')
 subdir('Dump')
 subdir('Hardware')
+subdir('Host')
 subdir('License')
 subdir('Logging')
 subdir('PLDM')

--- a/yaml/com/ibm/Host/Target.interface.yaml
+++ b/yaml/com/ibm/Host/Target.interface.yaml
@@ -1,0 +1,23 @@
+description: >
+    Implement to choose the hypervisor. This property reflects the user settings
+    and not a status. It is possible that the user can change the setting at any
+    point of time. But the property will be applied only when the host boots the
+    next time.
+
+properties:
+    - name: Target
+      type: enum[ self.Hypervisor ]
+      default: PowerVM
+      description: The desired hypervisor.
+
+enumerations:
+    - name: Hypervisor
+      description: >
+          Possible hypervisors.
+      values:
+          - name: PowerVM
+            description: >
+                PowerVM as the hypervisor.
+          - name: OPAL
+            description: >
+                OPAL as the hypervisor.


### PR DESCRIPTION
#### Dual-boot: BIOS attribute for choosing OS
```
This commit adds interface to choose the OS.
This property reflects the user settings and not a status.
It is possible that the user can change the setting
at any point of time. But the property will be applied
only when the host boots the next time.

The interface is contained within com.ibm.Host namespace.

Signed-off-by: Pavithra Barithaya <pbaritha@in.ibm.com>
Signed-off-by: Deepak Kodihalli <dkodihal@in.ibm.com>
```