### PR TITLE
Logging.Create: return result path from create call

### DIFF
--- a/yaml/xyz/openbmc_project/Logging/Create.interface.yaml
+++ b/yaml/xyz/openbmc_project/Logging/Create.interface.yaml
@@ -26,6 +26,11 @@ methods:
                   }
                 ends up in AdditionaData like:
                   ["KEY1=value1", "KEY2=value2"]
+      returns:
+          - name: Entry
+            type: object_path
+            description: >
+                The resulting object_path of the newly created Entry
 
     - name: CreateWithFFDCFiles
       description: >


### PR DESCRIPTION
When a daemon creates an event or error entry it is sometimes helpful to be able to look up that entry later, for example to mark it as resolved.  Add a return to the method call for this.


Change-Id: Ia010e53fda55cef8b9cfc948482e133f20040320