### PR TITLE
Add IsGenerateSecretKeyRequired D-bus method

### DIFF
--- a/yaml/xyz/openbmc_project/User/TOTPAuthenticator.interface.yaml
+++ b/yaml/xyz/openbmc_project/User/TOTPAuthenticator.interface.yaml
@@ -35,6 +35,18 @@ methods:
             description: >
                 Returns true if provided OTP is valid otherwise returns false.
 
+    - name: IsGenerateSecretKeyRequired
+      description: >
+          This method returns whether TOTP authenticator secret key setup
+          required for the given user to complete Time-based One-time Password
+          authentication setup
+      returns:
+          - name: Status
+            type: boolean
+            description: >
+                Returns true if secret key setup required for given user
+                otherwise returns false.
+
 properties:
     - name: SecretKeyIsValid
       type: boolean


### PR DESCRIPTION
This commit adds IsGenerateSecretekeyRequired() D-bus method This D-bus method identifies whether TOTP secret key setup required for a given user.

Change-Id: I5dbc5d2091b8d8f97295ffceec1b29cc94b85aed