### PR TITLE
PCIeLink and Cable Status DBus Interface

### DIFF
--- a/yaml/xyz/openbmc_project/Inventory/Item/Cable.interface.yaml
+++ b/yaml/xyz/openbmc_project/Inventory/Item/Cable.interface.yaml
@@ -17,6 +17,28 @@ properties:
           user interfaces but this field should not be used for programmatic
           interrogation of a cable beyond ignoring the default value of the
           empty string.
+    - name: CableStatus
+      type: enum[self.Status]
+      default: "Unknown"
+      description: >
+          The status of the cable. The default status is unknown.
+enumerations:
+    - name: Status
+      description: >
+          Possible cable status
+      values:
+          - name: "Inactive"
+            description: >
+                Cable is inactive.
+          - name: "Running"
+            description: >
+                Cable is running.
+          - name: "PoweredOff"
+            description: >
+                Cable is powered off.
+          - name: "Unknown"
+            description: >
+                Cable status is unknown.
 
 associations:
     - name: downstream_chassis

--- a/yaml/xyz/openbmc_project/Inventory/Item/PCIeSlot.interface.yaml
+++ b/yaml/xyz/openbmc_project/Inventory/Item/PCIeSlot.interface.yaml
@@ -25,6 +25,17 @@ properties:
       description: >
           Whether this PCIe slot supports hotplug
 
+    - name: LinkStatus
+      type: enum[self.Status]
+      default: "Unknown"
+      description: >
+          Status of PCIe bus linked to the slot.
+
+    - name: BusId
+      type: size
+      description: >
+          Identifier to detect the PCIe bus linked to the slot.
+
 enumerations:
     - name: Generations
       description: >
@@ -97,6 +108,30 @@ enumerations:
           - name: "Unknown"
             description: >
                 Type of the PCIe slot is unknown
+
+    - name: Status
+      description: >
+          Possible link status
+      values:
+          - name: "Operational"
+            description: >
+                Link is operational
+          - name: "Degraded"
+            description: >
+                Link is degraded
+          - name: "Failed"
+            description: >
+                Link failed
+          - name: "Open"
+            description: >
+                Link is open
+
+          - name: "Inactive"
+            description: >
+                Link is inactive
+          - name: "Unknown"
+            description: >
+                Link status is unknown
 
 association:
     name: connected_to


### PR DESCRIPTION
This commit-
- defines new enum property called CableStatus under the Cable Interface.
- defines property to hold PCIe link status value for a given PCIe slot.
- adds property BusId to PCIeSlot interfce, the property will be required to detect the bus on which the slot resides.

Change-Id: Id9b785e2971c8cd9a05e5bdac81f36f6bbd3f102
Signed-off-by: Pavithra Barithaya <pavithrabarithaya07@gmail.com>