### PR TITLE
Network: Add LLDP support on ethernet interfaces

### DIFF
--- a/yaml/xyz/openbmc_project/Network/EthernetInterface.interface.yaml
+++ b/yaml/xyz/openbmc_project/Network/EthernetInterface.interface.yaml
@@ -109,7 +109,14 @@ properties:
           https://man7.org/linux/man-pages/man3/inet_pton.3.html
       errors:
           - xyz.openbmc_project.Common.Error.InvalidArgument
-
+    - name: EmitLLDP
+      type: boolean
+      default: false
+      description: >
+          Boolean for controlling LLDP packet emission on the ethernet
+          interface. The Link Layer Discovery Protocol is a link layer protocol
+          used by network devices for advertising their identity, capabilities,
+          and neighbors on a local area network based on IEEE 802 technology.
 enumerations:
     - name: LinkLocalConf
       description: >


### PR DESCRIPTION
The Link Layer Discovery Protocol (LLDP) is a vendor-neutral link layer protocol used by network devices for advertising their identity, capabilities, and neighbors on a local area network based on IEEE 802

This commit adds D-bus properties to control LLDP on ethernet interfaces

Systemd-network supports
[1] https://www.freedesktop.org/software/systemd/man/latest/systemd.network.html#EmitLLDP=

Change-Id: Iacd411c7d89367a6e3c7a546e71c59817d3fe970