### PR TITLE
DataSync: Added the "BMCData" interface

### DIFF
--- a/gen/xyz/openbmc_project/DataSync/BMCData/meson.build
+++ b/gen/xyz/openbmc_project/DataSync/BMCData/meson.build
@@ -1,0 +1,15 @@
+# Generated file; do not modify.
+generated_sources += custom_target(
+    'xyz/openbmc_project/DataSync/BMCData__cpp'.underscorify(),
+    input: [ '../../../../../yaml/xyz/openbmc_project/DataSync/BMCData.interface.yaml',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'aserver.hpp', 'client.hpp',  ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'cpp',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../yaml',
+        'xyz/openbmc_project/DataSync/BMCData',
+    ],
+)
+

--- a/gen/xyz/openbmc_project/DataSync/meson.build
+++ b/gen/xyz/openbmc_project/DataSync/meson.build
@@ -1,0 +1,16 @@
+# Generated file; do not modify.
+subdir('BMCData')
+generated_others += custom_target(
+    'xyz/openbmc_project/DataSync/BMCData__markdown'.underscorify(),
+    input: [ '../../../../yaml/xyz/openbmc_project/DataSync/BMCData.interface.yaml',  ],
+    output: [ 'BMCData.md' ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'markdown',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../yaml',
+        'xyz/openbmc_project/DataSync/BMCData',
+    ],
+)
+

--- a/gen/xyz/openbmc_project/meson.build
+++ b/gen/xyz/openbmc_project/meson.build
@@ -52,6 +52,7 @@ generated_others += custom_target(
 subdir('Condition')
 subdir('Console')
 subdir('Control')
+subdir('DataSync')
 subdir('Debug')
 subdir('Dump')
 subdir('HardwareIsolation')

--- a/yaml/xyz/openbmc_project/DataSync/BMCData.interface.yaml
+++ b/yaml/xyz/openbmc_project/DataSync/BMCData.interface.yaml
@@ -1,0 +1,20 @@
+description: >
+    Implement the transfer of BMC application data to redundant BMC.
+
+properties:
+    - name: DisableSync
+      type: boolean
+      default: false
+      description: >
+          It can be utilized to disable synchronization when the redundant BMC
+          is in a faulty state.
+
+          It does not interrupt ongoing sync operations. If the redundant BMC
+          network is unstable, the ongoing sync operation will fail and attempt
+          retries. However, it will not proceed if this property value is set to
+          true.
+
+paths:
+    - namespace: /xyz/openbmc_project/data_sync/bmc_data
+      description: >
+          The root path for data synchronization between BMCs.


### PR DESCRIPTION
- Introduced a new interface, "BMCData," to facilitate syncing BMC data between redundant BMC systems, as outlined in the following design document, https://gerrit.openbmc.org/c/openbmc/docs/+/71039.

- This interface can be implemented by application to enable data synchronization services in redundant BMC setups.

- The interface is started with an object path to allow application to host and manage data sync services.
