### PR TITLE
State: Add DisableRedundancyOverride property

### DIFF
--- a/yaml/xyz/openbmc_project/State/BMC/Redundancy.interface.yaml
+++ b/yaml/xyz/openbmc_project/State/BMC/Redundancy.interface.yaml
@@ -19,6 +19,21 @@ properties:
           If redundancy is currently enabled.  In general, this means that the
           BMCs are configured as active and passive and that the passive is able
           to be failed over to.
+    - name: DisableRedundancyOverride
+      type: boolean
+      default: false
+      errors:
+          - xyz.openbmc_project.Common.Error.Unavailable
+      description: >
+          This is used to immediately and persistently disable redundancy.  The
+          use case is there are test phases where redundancy is not wanted and
+          this is how that is accomplished.
+
+          If set back to true, redundancy will immediately be re-enabled,
+          assuming nothing else is preventing it.
+
+          This can only be changed on the active BMC and when power is off,
+          otherwise it will throw the Unavailable error.
 
 enumerations:
     - name: Role


### PR DESCRIPTION
This property is used to manually disable redundancy, for use in at least testing and manufacturing environments.

Change-Id: I7073532c1de5cf17b045ce09ba58f395c2d408f8