### PR TITLE
DataSync: Added error code, method, property and Enum

### DIFF
--- a/yaml/xyz/openbmc_project/DataSync/BMCData.errors.yaml
+++ b/yaml/xyz/openbmc_project/DataSync/BMCData.errors.yaml
@@ -1,0 +1,2 @@
+- name: SiblingNotAvailable
+  description: Sibling is currently not available.

--- a/yaml/xyz/openbmc_project/DataSync/BMCData.interface.yaml
+++ b/yaml/xyz/openbmc_project/DataSync/BMCData.interface.yaml
@@ -22,6 +22,28 @@ properties:
           retries. However, it will not proceed if this property value is set to
           true.
 
+    - name: SyncStatus
+      type: enum[self.SyncStatus]
+      default: Unknown
+      description: >
+          This property represents the current status of the full synchronization
+          process.
+
+enumerations:
+    - name: SyncStatus
+      description: >
+          Defines the current Synchronization status of the BMC.
+      values:
+          - name: Unknown
+            description: >
+                The synchronization status is not yet determined or is
+                in an indeterminate state.
+
+          - name: FullSyncCompleted
+            description: >
+                The full Sync of all the configured files and directory based on 
+                role is completed.
+
 paths:
     - namespace: /xyz/openbmc_project/data_sync/bmc_data
       description: >

--- a/yaml/xyz/openbmc_project/DataSync/BMCData.interface.yaml
+++ b/yaml/xyz/openbmc_project/DataSync/BMCData.interface.yaml
@@ -1,6 +1,14 @@
 description: >
     Implement the transfer of BMC application data to redundant BMC.
 
+methods:
+    - name: FullSync
+      description: >
+          Start a full Sync of all the configured files and directory based 
+          on role, to the sibling BMC.
+      errors:
+          - xyz.openbmc_project.DataSync.BMCData.Error.SiblingNotAvailable
+
 properties:
     - name: DisableSync
       type: boolean


### PR DESCRIPTION
- Introduced the "SiblingNotAvailable" error code specific to 
DataSync interfaces.
- Introduced the "FullSync" method interface to initiate a full 
sync of the configured files and directory to the sibling BMC.
- Introduced the "SyncStatus" property and Enum to define the 
Synchronization status of the BMC.

