### PR TITLE
Add new interface to define sensor purpose

### DIFF
--- a/gen/xyz/openbmc_project/Sensor/Purpose/meson.build
+++ b/gen/xyz/openbmc_project/Sensor/Purpose/meson.build
@@ -1,0 +1,15 @@
+# Generated file; do not modify.
+generated_sources += custom_target(
+    'xyz/openbmc_project/Sensor/Purpose__cpp'.underscorify(),
+    input: [ '../../../../../yaml/xyz/openbmc_project/Sensor/Purpose.interface.yaml',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'aserver.hpp', 'client.hpp',  ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'cpp',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../yaml',
+        'xyz/openbmc_project/Sensor/Purpose',
+    ],
+)
+

--- a/gen/xyz/openbmc_project/Sensor/meson.build
+++ b/gen/xyz/openbmc_project/Sensor/meson.build
@@ -29,6 +29,21 @@ generated_others += custom_target(
     ],
 )
 
+subdir('Purpose')
+generated_others += custom_target(
+    'xyz/openbmc_project/Sensor/Purpose__markdown'.underscorify(),
+    input: [ '../../../../yaml/xyz/openbmc_project/Sensor/Purpose.interface.yaml',  ],
+    output: [ 'Purpose.md' ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'markdown',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../yaml',
+        'xyz/openbmc_project/Sensor/Purpose',
+    ],
+)
+
 subdir('Threshold')
 generated_others += custom_target(
     'xyz/openbmc_project/Sensor/Threshold__markdown'.underscorify(),

--- a/yaml/xyz/openbmc_project/Sensor/Purpose.interface.yaml
+++ b/yaml/xyz/openbmc_project/Sensor/Purpose.interface.yaml
@@ -1,0 +1,29 @@
+description: >
+    Implement to provide detail on any special purpose of the sensor. Useful for
+    defining sensors which provide summary information, see enum for defined
+    types.
+
+    Objects implementing Sensor.Purpose must also implement Sensor.Value.
+
+properties:
+    - name: Purpose
+      type: set[enum[self.SensorPurpose]]
+      flags:
+          - readonly
+      description: >
+          Defines the special purposes for the sensor.
+
+enumerations:
+    - name: SensorPurpose
+      description: >
+          The special purposes for a sensor.
+      values:
+          - name: TotalPower
+            description: >
+                Sensor provides total power for the Inventory.Item associated to
+                this sensor. The existing all_sensors/chassis association is
+                used. Future direction is to use the monitoring/monitored_by
+                association instead.
+
+paths:
+    - namespace: /xyz/openbmc_project/sensors


### PR DESCRIPTION
A chassis can have a sensor which tracks the total power consumption. Clients such as bmcweb need a programmatic approach to finding the unique sensor from the chassis.

A design discussion [1] in development channel of Discord settled on the following approach:
 - Define a D-Bus interface for defining a special purpose for a sensor.
 - Use the existing all_sensors/chassis association to connect the sensor to its Chassis.
 - Clients such as bmcweb use object mapper to find all_sensors associated with the Chassis. They then filter to find the sensor implementing the specific purpose required.

This initial implementation only defines a single special purpose. The expectation is others will be added as needed in the future.

The openpower-occ-control repo implemented a total_power association.[2] This will be modified to implement this new interface on the total_power sensor.

There is a commit for bmcweb which will be modified to use this new approach for finding the total_power sensor.[3]

Note: There is technical debt to convert all_sensors/chassis associations to use the monitoring/monitored_by association instead.[4] That change would also need to convert the association used to find objects implementing this interface.

[1] https://discord.com/channels/775381525260664832/867820390406422538/1326612654852280433
[2] https://gerrit.openbmc.org/c/openbmc/openpower-occ-control/+/75572
[3] https://gerrit.openbmc.org/c/openbmc/bmcweb/+/57717
[4] https://discord.com/channels/775381525260664832/867820390406422538/1326609419022372916

Change-Id: Ic8b509c9b2b17e823243f7b784ef941ec461cddb