### PR TITLE
vpd:Create default error interface

### DIFF
--- a/yaml/com/ibm/VPD.errors.yaml
+++ b/yaml/com/ibm/VPD.errors.yaml
@@ -28,3 +28,7 @@
       Could not determine which device tree to switch to, as system type is
       unknown. Please check the HW and  IM keywords in the system VPD and check
       if they are programmed correctly.
+- name: DefaultError
+  description:
+      Error processing the VPD request. This can be used as a default error
+      type.


### PR DESCRIPTION
This commit creates a default error type for VPD related errors. When no specific error type is matching, this default error type can be published in error logs.

Change-Id: I80e368f2aeda90b18d0243644ac133c54c102141