### PR TITLE
SyncBMCData: Added interface, error code, method, property and enum 

### DIFF
--- a/gen/xyz/openbmc_project/Control/SyncBMCData/meson.build
+++ b/gen/xyz/openbmc_project/Control/SyncBMCData/meson.build
@@ -1,0 +1,40 @@
+# Generated file; do not modify.
+
+sdbusplus_current_path = 'xyz/openbmc_project/Control/SyncBMCData'
+
+generated_sources += custom_target(
+    'xyz/openbmc_project/Control/SyncBMCData__cpp'.underscorify(),
+    input: [
+        '../../../../../yaml/xyz/openbmc_project/Control/SyncBMCData.interface.yaml',
+    ],
+    output: [
+        'common.hpp',
+        'server.hpp',
+        'server.cpp',
+        'aserver.hpp',
+        'client.hpp',
+    ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog,
+        '--command',
+        'cpp',
+        '--output',
+        meson.current_build_dir(),
+        '--tool',
+        sdbusplusplus_prog,
+        '--directory',
+        meson.current_source_dir() / '../../../../../yaml',
+        'xyz/openbmc_project/Control/SyncBMCData',
+    ],
+    install: should_generate_cpp,
+    install_dir: [
+        get_option('includedir') / sdbusplus_current_path,
+        get_option('includedir') / sdbusplus_current_path,
+        false,
+        get_option('includedir') / sdbusplus_current_path,
+        get_option('includedir') / sdbusplus_current_path,
+    ],
+    build_by_default: should_generate_cpp,
+)
+

--- a/gen/xyz/openbmc_project/Control/SyncBMCData/meson.build
+++ b/gen/xyz/openbmc_project/Control/SyncBMCData/meson.build
@@ -5,9 +5,12 @@ sdbusplus_current_path = 'xyz/openbmc_project/Control/SyncBMCData'
 generated_sources += custom_target(
     'xyz/openbmc_project/Control/SyncBMCData__cpp'.underscorify(),
     input: [
+        '../../../../../yaml/xyz/openbmc_project/Control/SyncBMCData.errors.yaml',
         '../../../../../yaml/xyz/openbmc_project/Control/SyncBMCData.interface.yaml',
     ],
     output: [
+        'error.cpp',
+        'error.hpp',
         'common.hpp',
         'server.hpp',
         'server.cpp',
@@ -29,6 +32,8 @@ generated_sources += custom_target(
     ],
     install: should_generate_cpp,
     install_dir: [
+        false,
+        get_option('includedir') / sdbusplus_current_path,
         get_option('includedir') / sdbusplus_current_path,
         get_option('includedir') / sdbusplus_current_path,
         false,

--- a/gen/xyz/openbmc_project/Control/meson.build
+++ b/gen/xyz/openbmc_project/Control/meson.build
@@ -312,6 +312,7 @@ generated_markdown += custom_target(
 generated_markdown += custom_target(
     'xyz/openbmc_project/Control/SyncBMCData__markdown'.underscorify(),
     input: [
+        '../../../../yaml/xyz/openbmc_project/Control/SyncBMCData.errors.yaml',
         '../../../../yaml/xyz/openbmc_project/Control/SyncBMCData.interface.yaml',
     ],
     output: ['SyncBMCData.md'],

--- a/gen/xyz/openbmc_project/Control/meson.build
+++ b/gen/xyz/openbmc_project/Control/meson.build
@@ -16,6 +16,7 @@ subdir('PowerSupplyRedundancy')
 subdir('Processor')
 subdir('Security')
 subdir('Service')
+subdir('SyncBMCData')
 subdir('TPM')
 subdir('ThermalMode')
 subdir('VoltageRegulatorControl')
@@ -302,6 +303,30 @@ generated_markdown += custom_target(
         '--directory',
         meson.current_source_dir() / '../../../../yaml',
         'xyz/openbmc_project/Control/PowerSupplyRedundancy',
+    ],
+    install: should_generate_markdown,
+    install_dir: [inst_markdown_dir / sdbusplus_current_path],
+    build_by_default: should_generate_markdown,
+)
+
+generated_markdown += custom_target(
+    'xyz/openbmc_project/Control/SyncBMCData__markdown'.underscorify(),
+    input: [
+        '../../../../yaml/xyz/openbmc_project/Control/SyncBMCData.interface.yaml',
+    ],
+    output: ['SyncBMCData.md'],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog,
+        '--command',
+        'markdown',
+        '--output',
+        meson.current_build_dir(),
+        '--tool',
+        sdbusplusplus_prog,
+        '--directory',
+        meson.current_source_dir() / '../../../../yaml',
+        'xyz/openbmc_project/Control/SyncBMCData',
     ],
     install: should_generate_markdown,
     install_dir: [inst_markdown_dir / sdbusplus_current_path],

--- a/yaml/xyz/openbmc_project/Control/SyncBMCData.errors.yaml
+++ b/yaml/xyz/openbmc_project/Control/SyncBMCData.errors.yaml
@@ -1,0 +1,5 @@
+- name: SiblingBMCNotAvailable
+  description: Sibling BMC is currently not available.
+
+- name: FullSyncInProgress
+  description: Full Sync is currently in progress.

--- a/yaml/xyz/openbmc_project/Control/SyncBMCData.interface.yaml
+++ b/yaml/xyz/openbmc_project/Control/SyncBMCData.interface.yaml
@@ -1,6 +1,15 @@
 description: >
     Implement the transfer of BMC application data to redundant BMC.
 
+methods:
+    - name: StartFullSync
+      description: >
+          Start a full Sync of all the configured files and directory based on
+          role, to the sibling BMC.
+      errors:
+          - self.Error.SiblingBMCNotAvailable
+          - self.Error.FullSyncInProgress
+
 properties:
     - name: DisableSync
       type: boolean

--- a/yaml/xyz/openbmc_project/Control/SyncBMCData.interface.yaml
+++ b/yaml/xyz/openbmc_project/Control/SyncBMCData.interface.yaml
@@ -23,6 +23,39 @@ properties:
           retries. However, it will not proceed if this property value is set to
           true.
 
+    - name: FullSyncStatus
+      type: enum[self.FullSyncStatus]
+      flags:
+          - readonly
+      default: Unknown
+      description: >
+          This property represents the current status of the full
+          synchronization process and is read-only.
+
+enumerations:
+    - name: FullSyncStatus
+      description: >
+          Defines the latest full Synchronization request status of the BMC.
+      values:
+          - name: Unknown
+            description: >
+                The full synchronization status is not yet determined or is in
+                an indeterminate state.
+
+          - name: FullSyncInProgress
+            description: >
+                The full synchronization is in progress.
+
+          - name: FullSyncCompleted
+            description: >
+                The full Sync of all the configured files and directory based on
+                role is successfully completed.
+
+          - name: FullSyncFailed
+            description: >
+                The full synchronization process has failed due to an error or
+                failure in one or more of the configured files or directories.
+
 paths:
     - instance: /xyz/openbmc_project/control/sync_bmc_data
       description: >

--- a/yaml/xyz/openbmc_project/Control/SyncBMCData.interface.yaml
+++ b/yaml/xyz/openbmc_project/Control/SyncBMCData.interface.yaml
@@ -1,0 +1,20 @@
+description: >
+    Implement the transfer of BMC application data to redundant BMC.
+
+properties:
+    - name: DisableSync
+      type: boolean
+      default: false
+      description: >
+          It can be utilized to disable synchronization when the redundant BMC
+          is in a faulty state.
+
+          It does not interrupt ongoing sync operations. If the redundant BMC
+          network is unstable, the ongoing sync operation will fail and attempt
+          retries. However, it will not proceed if this property value is set to
+          true.
+
+paths:
+    - instance: /xyz/openbmc_project/control/sync_bmc_data
+      description: >
+          The root path for data synchronization between BMCs.


### PR DESCRIPTION
- Introduced the "SiblingBMCNotAvailable" and "FullSyncInProgress" error code specific to SyncBMCData interfaces.
- Introduced the "StartFullSync" method interface to initiate a full sync of the configured files and directory to the sibling BMC.
- Introduced the "DisableSync" and "FullSyncStatus" property and Enum to define the Full Synchronization status of the BMC.

This PR is on top of [Rebase](https://github.com/ibm-openbmc/phosphor-dbus-interfaces/pull/166) effort.
Included patches: [patch1](https://gerrit.openbmc.org/c/openbmc/phosphor-dbus-interfaces/+/76289), [patch2](https://gerrit.openbmc.org/c/openbmc/phosphor-dbus-interfaces/+/77378/6), [patch3](https://gerrit.openbmc.org/c/openbmc/phosphor-dbus-interfaces/+/77379/7), [patch4](https://gerrit.openbmc.org/c/openbmc/phosphor-dbus-interfaces/+/77380/8)