### PR TITLE
SyncBMCData: Added 'SyncDisabled' error code

### DIFF
--- a/yaml/xyz/openbmc_project/Control/SyncBMCData.errors.yaml
+++ b/yaml/xyz/openbmc_project/Control/SyncBMCData.errors.yaml
@@ -3,3 +3,6 @@
 
 - name: FullSyncInProgress
   description: Full Sync is currently in progress.
+
+- name: SyncDisabled
+  description: Sync is currently disabled.

--- a/yaml/xyz/openbmc_project/Control/SyncBMCData.interface.yaml
+++ b/yaml/xyz/openbmc_project/Control/SyncBMCData.interface.yaml
@@ -9,6 +9,7 @@ methods:
       errors:
           - self.Error.SiblingBMCNotAvailable
           - self.Error.FullSyncInProgress
+          - self.Error.SyncDisabled
 
 properties:
     - name: DisableSync


### PR DESCRIPTION
- Introduced the 'SyncDisabled' error code specific to SyncBMCData interfaces.
  - This error is triggered when a sync request is made while syncing is disabled.
- The 'StartFullSync' method now throws the following exception 
  - xyz.openbmc_project.Control.SyncBMCData.Error.SyncDisabled
    - Triggered when sync is disabled.

This PR includes upstream [patch](https://gerrit.openbmc.org/c/openbmc/phosphor-dbus-interfaces/+/78497/2). 

Change-Id: Ib3e787a4ee4768305ef0dbfab547107f9d6ba729
Signed-off-by: Harsh Agarwal <Harsh.Agarwal@ibm.com>