### PR TITLE
create detect-secrets baseline file

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-09-17T18:14:09Z",
+  "generated_at": "2025-03-25T14:17:37Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -82,7 +82,7 @@
         "hashed_secret": "1d550c76faec4793a038dad66bf0acbd56a78bd6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3,
+        "line_number": 6,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -90,7 +90,7 @@
         "hashed_secret": "287aa7ca33e2caf581397144b4d99ce2bac77a31",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 12,
+        "line_number": 28,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
@@ -100,7 +100,7 @@
         "hashed_secret": "3b4d89f26594b275f7572bb14fed31ac4c9b5981",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 19,
+        "line_number": 33,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -108,7 +108,7 @@
         "hashed_secret": "32cae99c56c08352b024c5143a153260ff0732de",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 34,
+        "line_number": 57,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -116,7 +116,7 @@
         "hashed_secret": "287aa7ca33e2caf581397144b4d99ce2bac77a31",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 43,
+        "line_number": 73,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
@@ -126,7 +126,7 @@
         "hashed_secret": "beaf12e8c0c79b996153a9a092be92cf3d91ca9c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 34,
+        "line_number": 60,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -134,7 +134,7 @@
         "hashed_secret": "e2e32c3eee55c7add306363fdc718825649e9701",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 49,
+        "line_number": 84,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
@@ -144,7 +144,51 @@
         "hashed_secret": "80c36b2abfa06bf08cfcc8824e6cb06c7fc2147d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4,
+        "line_number": 8,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "gen/xyz/openbmc_project/Configuration/GPIOLeakDetector/meson.build": [
+      {
+        "hashed_secret": "b39b1034530f6f7625ec31513bb05fcad802c3a9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 6,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "66cc3e1207f1fb9d5564becb4a00ceb8dbe13e64",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 28,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "gen/xyz/openbmc_project/Configuration/meson.build": [
+      {
+        "hashed_secret": "804ce4d601579a90a634f9bd80b0aabd44e94ab5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 8,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b1e01d73780b853259e7ebebd2324485cb5cb247",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 32,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "66cc3e1207f1fb9d5564becb4a00ceb8dbe13e64",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 48,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
@@ -154,7 +198,7 @@
         "hashed_secret": "da76e96b446dd5cd2e7605d4f13ac74e64e17506",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 125,
+        "line_number": 219,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
@@ -164,7 +208,7 @@
         "hashed_secret": "2a047bb010642adc3c0c183ac14c3ee12b5dcd2d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4,
+        "line_number": 8,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
@@ -174,7 +218,7 @@
         "hashed_secret": "fc6f4d36b80c3d54920e885311880b46b0b8c01a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 33,
+        "line_number": 68,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
@@ -184,7 +228,7 @@
         "hashed_secret": "4369b59019efa5f62d3a5719df57d5f97f556cac",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 154,
+        "line_number": 289,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
@@ -194,7 +238,7 @@
         "hashed_secret": "ed066715a8cabc2f70d8cf1cbd12f7c8f8fecf9d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4,
+        "line_number": 8,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -202,7 +246,7 @@
         "hashed_secret": "37a9d713fcefe8778921871d4c427a601f5f6892",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 19,
+        "line_number": 32,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
@@ -212,7 +256,7 @@
         "hashed_secret": "3323ecc48acbbb5cd7092de250a6ddb41123f60c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 44,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -220,7 +264,7 @@
         "hashed_secret": "76f39990b87c80c1d44710398020878b1fd12c18",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 33,
+        "line_number": 68,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
@@ -230,25 +274,7 @@
         "hashed_secret": "9e7a358e66720aa777c00979fbd0f6d228ef2ebe",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3,
-        "type": "Base64 High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "d851dc305439492d378c4bd7fdbba6d04a7036cd",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 12,
-        "type": "Base64 High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "gen/xyz/openbmc_project/Network/meson.build": [
-      {
-        "hashed_secret": "749d2ad3b2fcb46239b98ec4afc1beae17d42341",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 19,
+        "line_number": 6,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -259,12 +285,30 @@
         "line_number": 28,
         "type": "Base64 High Entropy String",
         "verified_result": null
+      }
+    ],
+    "gen/xyz/openbmc_project/Network/meson.build": [
+      {
+        "hashed_secret": "749d2ad3b2fcb46239b98ec4afc1beae17d42341",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 40,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d851dc305439492d378c4bd7fdbba6d04a7036cd",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 56,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
       },
       {
         "hashed_secret": "3e6b488f536ae81f62ca63d306e85e03e8e3d1e7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 110,
+        "line_number": 182,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
@@ -274,7 +318,7 @@
         "hashed_secret": "b0493f4ddfa3fd8f0a95bbd0ec41199a5f1720fd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4,
+        "line_number": 7,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
@@ -284,7 +328,7 @@
         "hashed_secret": "d2450afd9d321f5d3ee26b2af1b97c09fac7d660",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3,
+        "line_number": 6,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -292,7 +336,7 @@
         "hashed_secret": "6a94192043110ed2b45024e7c520f46bd0c834c3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 12,
+        "line_number": 28,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
@@ -302,7 +346,7 @@
         "hashed_secret": "8c3a14e0eb992744f256c371fbdf9fcf75fba687",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4,
+        "line_number": 7,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -310,7 +354,7 @@
         "hashed_secret": "6a94192043110ed2b45024e7c520f46bd0c834c3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 13,
+        "line_number": 23,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
@@ -320,7 +364,7 @@
         "hashed_secret": "7c1559337ee017c391d9fdf71bd21a0d844829ca",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 35,
+        "line_number": 54,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
@@ -330,7 +374,7 @@
         "hashed_secret": "b8316d87f557089e77c311472270a9d42f26f148",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 64,
+        "line_number": 151,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
@@ -340,7 +384,7 @@
         "hashed_secret": "38803c78c53c42ca138338449014696f81507819",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4,
+        "line_number": 7,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
@@ -350,7 +394,7 @@
         "hashed_secret": "5c7e6b242439fcc19500e807c5d9a411028ee7d2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 43,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
@@ -360,17 +404,59 @@
         "hashed_secret": "9d16c7d69920531d7952f7a0840173bed423ee22",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 97,
+        "line_number": 210,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "gen/xyz/openbmc_project/User/MultiFactorAuthConfiguration/meson.build": [
+      {
+        "hashed_secret": "ba6dad05dca3d3ffa96eba43bb2948422738a31c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 6,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "404381708beb3d47d06b50d718d439f85e7317db",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 28,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
     ],
     "gen/xyz/openbmc_project/User/meson.build": [
       {
+        "hashed_secret": "386caf1f935e1de68ca288a849e182b9e473a9e7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 108,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "404381708beb3d47d06b50d718d439f85e7317db",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 124,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "46ad9d5d636b9d724a333f5a6342d933dcc102db",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 80,
+        "line_number": 156,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "042f534052803a513910c79740705d013f429a02",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 180,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
@@ -380,7 +466,7 @@
         "hashed_secret": "415062e8efc67b4d41a4071adfaa16b72ea0656a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4,
+        "line_number": 11,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -388,7 +474,7 @@
         "hashed_secret": "cb5504b6d9122ce2d2a770b3fad053699fa5827f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 34,
+        "line_number": 59,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -396,7 +482,7 @@
         "hashed_secret": "05fdd4c42faad6eaecff6d5078c4ba7f20a6e226",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 64,
+        "line_number": 107,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }


### PR DESCRIPTION
This creates a baseline file (and initial responses to any potential secrets found).

After this file is merged, all CI jobs after will run the detect-secrets tool against incoming commits to verify no potential secrets are being shared. If one is found, CI will fail until the .secrets.baseline is updated for the new issue.

See the following for more info:
  https://github.com/IBM/detect-secrets