### PR TITLE
Update VPD.errors.yaml

### DIFF
--- a/yaml/com/ibm/VPD.errors.yaml
+++ b/yaml/com/ibm/VPD.errors.yaml
@@ -29,5 +29,4 @@
       unknown. Please check the HW and  IM keywords in the system VPD and check
       if they are programmed correctly.
 - name: FirmwareError
-  description:
-      A standard runtime exception thrown by VPD Manager firmware code.
+  description: A standard runtime exception thrown by VPD Manager firmware code.

--- a/yaml/com/ibm/VPD.errors.yaml
+++ b/yaml/com/ibm/VPD.errors.yaml
@@ -28,3 +28,6 @@
       Could not determine which device tree to switch to, as system type is
       unknown. Please check the HW and  IM keywords in the system VPD and check
       if they are programmed correctly.
+- name: FirmwareError
+  description:
+      A standard runtime exception thrown by VPD Manager firmware code.


### PR DESCRIPTION
Addition of Firmware error to populate com.ibm.VPD.Error.FirmwareError, the same will be used to log PEL in case any standard runtime exception is thrown by VPD Manager firmware code.