### PR TITLE
1120: Update VPD.errors.yaml (#172)

### DIFF
--- a/yaml/com/ibm/VPD.errors.yaml
+++ b/yaml/com/ibm/VPD.errors.yaml
@@ -28,3 +28,5 @@
       Could not determine which device tree to switch to, as system type is
       unknown. Please check the HW and  IM keywords in the system VPD and check
       if they are programmed correctly.
+- name: FirmwareError
+  description: A standard runtime exception thrown by VPD Manager firmware code.


### PR DESCRIPTION
#### Update VPD.errors.yaml (#172)
```
* Update VPD.errors.yaml

Addition of Firmware error to populate com.ibm.VPD.Error.FirmwareError, the same will be used to log PEL in case any standard runtime exception is thrown by VPD Manager firmware code.

* Update VPD.errors.yaml```