### PR TITLE
Control: Add Failover interface

### DIFF
--- a/gen/xyz/openbmc_project/Control/Failover/meson.build
+++ b/gen/xyz/openbmc_project/Control/Failover/meson.build
@@ -1,0 +1,40 @@
+# Generated file; do not modify.
+
+sdbusplus_current_path = 'xyz/openbmc_project/Control/Failover'
+
+generated_sources += custom_target(
+    'xyz/openbmc_project/Control/Failover__cpp'.underscorify(),
+    input: [
+        '../../../../../yaml/xyz/openbmc_project/Control/Failover.interface.yaml',
+    ],
+    output: [
+        'common.hpp',
+        'server.hpp',
+        'server.cpp',
+        'aserver.hpp',
+        'client.hpp',
+    ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog,
+        '--command',
+        'cpp',
+        '--output',
+        meson.current_build_dir(),
+        '--tool',
+        sdbusplusplus_prog,
+        '--directory',
+        meson.current_source_dir() / '../../../../../yaml',
+        'xyz/openbmc_project/Control/Failover',
+    ],
+    install: should_generate_cpp,
+    install_dir: [
+        get_option('includedir') / sdbusplus_current_path,
+        get_option('includedir') / sdbusplus_current_path,
+        false,
+        get_option('includedir') / sdbusplus_current_path,
+        get_option('includedir') / sdbusplus_current_path,
+    ],
+    build_by_default: should_generate_cpp,
+)
+

--- a/gen/xyz/openbmc_project/Control/meson.build
+++ b/gen/xyz/openbmc_project/Control/meson.build
@@ -3,6 +3,7 @@ subdir('Boot')
 subdir('CFMLimit')
 subdir('ChassisCapabilities')
 subdir('Device')
+subdir('Failover')
 subdir('FanPwm')
 subdir('FanRedundancy')
 subdir('FanSpeed')
@@ -88,6 +89,30 @@ generated_markdown += custom_target(
         '--directory',
         meson.current_source_dir() / '../../../../yaml',
         'xyz/openbmc_project/Control/Device',
+    ],
+    install: should_generate_markdown,
+    install_dir: [inst_markdown_dir / sdbusplus_current_path],
+    build_by_default: should_generate_markdown,
+)
+
+generated_markdown += custom_target(
+    'xyz/openbmc_project/Control/Failover__markdown'.underscorify(),
+    input: [
+        '../../../../yaml/xyz/openbmc_project/Control/Failover.interface.yaml',
+    ],
+    output: ['Failover.md'],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog,
+        '--command',
+        'markdown',
+        '--output',
+        meson.current_build_dir(),
+        '--tool',
+        sdbusplusplus_prog,
+        '--directory',
+        meson.current_source_dir() / '../../../../yaml',
+        'xyz/openbmc_project/Control/Failover',
     ],
     install: should_generate_markdown,
     install_dir: [inst_markdown_dir / sdbusplus_current_path],

--- a/yaml/xyz/openbmc_project/Control/Failover.interface.yaml
+++ b/yaml/xyz/openbmc_project/Control/Failover.interface.yaml
@@ -1,0 +1,39 @@
+description: >
+    Implement to provide an interface to start a failover.  Depending on the
+    implementation, this may reside on the 'from' or 'to' object (or both).  The
+    'Options' method argument provides a mechanism to provide implementation
+    specific options.
+
+methods:
+    - name: StartFailover
+      description: >
+          Starts a failover operation.
+      parameters:
+          - name: Options
+            type: dict[string, variant[boolean]]
+            description: >
+                Additional options. The key is the string version of the Options
+                enum, in the form of
+                'xyz.openbmc_project.Control.Failover.Options.X'.
+      errors:
+          - xyz.openbmc_project.Common.Error.Unavailable
+
+properties:
+    - name: FailoverInProgress
+      type: boolean
+      default: false
+      flags:
+          - readonly
+      description: >
+          Indicates that a failover is in progress.
+
+enumerations:
+    - name: Options
+      description: >
+          Available options for starting the failover.
+      values:
+          - name: "Force"
+            description: >
+                A boolean option to force the failover when it would normally
+                not be available.  The checks it bypasses are implementation
+                dependent.


### PR DESCRIPTION
Create an interface to start a failover.  The first use will be to failover to another BMC, though the intent is the interface can also be used for other sorts of failovers.

Change-Id: I32789f6b8f01d1baed95d387e6815a797d5b45b8