### PR TITLE
State:Add FailoversAllowed to RBMC interfaces

### DIFF
--- a/yaml/xyz/openbmc_project/State/BMC/Redundancy.interface.yaml
+++ b/yaml/xyz/openbmc_project/State/BMC/Redundancy.interface.yaml
@@ -49,6 +49,16 @@ properties:
           not trigger any intervention that could be necessary when redundancy
           is lost just due to a BMC reboot.  Any time the passive BMC goes
           offline a full file sync would be necessary when it comes back.
+    - name: FailoversAllowed
+      type: boolean
+      flags:
+          - readonly
+      default: false
+      description: >
+          States if failovers are currently allowed. Even when redundancy is
+          enabled, a failover may not be allowed because there are periods when
+          doing a failover could cause issues, such as in the middle of a boot
+          or code update.
 
 enumerations:
     - name: Role

--- a/yaml/xyz/openbmc_project/State/BMC/Redundancy/Sibling.interface.yaml
+++ b/yaml/xyz/openbmc_project/State/BMC/Redundancy/Sibling.interface.yaml
@@ -47,6 +47,17 @@ properties:
           events, for example during a code update. This may only make sense if
           the sibling has the active role.
 
+    - name: FailoversAllowed
+      type: boolean
+      flags:
+          - readonly
+      default: false
+      description: >
+          States if failovers are currently allowed. Even when redundancy is
+          enabled, a failover may not be allowed because there are periods when
+          doing a failover could cause issues, such as in the middle of a boot
+          or code update.
+
     - name: BMCState
       type: enum[xyz.openbmc_project.State.BMC.BMCState]
       default: NotReady


### PR DESCRIPTION
This property indicates if a failover is allowed at any instance in time.  If redundancy is disabled, it will of course be false.

To stage in the conversion of the FailoversPaused to FailoversAllowed, leave in the original property while adding the new one.  The old one will be removed when everything points to the new one.

Note that the Sibling RBMC interface will eventually be removed in place of using separate interfaces.

Change-Id: I19ed39e8ae22a1902e33b4f7ca1a06b66181f139