### PR TITLE
RBMC interface updates

### DIFF
--- a/gen/xyz/openbmc_project/State/Decorator/Heartbeat/meson.build
+++ b/gen/xyz/openbmc_project/State/Decorator/Heartbeat/meson.build
@@ -1,0 +1,40 @@
+# Generated file; do not modify.
+
+sdbusplus_current_path = 'xyz/openbmc_project/State/Decorator/Heartbeat'
+
+generated_sources += custom_target(
+    'xyz/openbmc_project/State/Decorator/Heartbeat__cpp'.underscorify(),
+    input: [
+        '../../../../../../yaml/xyz/openbmc_project/State/Decorator/Heartbeat.interface.yaml',
+    ],
+    output: [
+        'common.hpp',
+        'server.hpp',
+        'server.cpp',
+        'aserver.hpp',
+        'client.hpp',
+    ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog,
+        '--command',
+        'cpp',
+        '--output',
+        meson.current_build_dir(),
+        '--tool',
+        sdbusplusplus_prog,
+        '--directory',
+        meson.current_source_dir() / '../../../../../../yaml',
+        'xyz/openbmc_project/State/Decorator/Heartbeat',
+    ],
+    install: should_generate_cpp,
+    install_dir: [
+        get_option('includedir') / sdbusplus_current_path,
+        get_option('includedir') / sdbusplus_current_path,
+        false,
+        get_option('includedir') / sdbusplus_current_path,
+        get_option('includedir') / sdbusplus_current_path,
+    ],
+    build_by_default: should_generate_cpp,
+)
+

--- a/gen/xyz/openbmc_project/State/Decorator/meson.build
+++ b/gen/xyz/openbmc_project/State/Decorator/meson.build
@@ -1,5 +1,6 @@
 # Generated file; do not modify.
 subdir('Availability')
+subdir('Heartbeat')
 subdir('OperationalStatus')
 subdir('PowerState')
 subdir('PowerSystemInputs')
@@ -24,6 +25,30 @@ generated_markdown += custom_target(
         '--directory',
         meson.current_source_dir() / '../../../../../yaml',
         'xyz/openbmc_project/State/Decorator/Availability',
+    ],
+    install: should_generate_markdown,
+    install_dir: [inst_markdown_dir / sdbusplus_current_path],
+    build_by_default: should_generate_markdown,
+)
+
+generated_markdown += custom_target(
+    'xyz/openbmc_project/State/Decorator/Heartbeat__markdown'.underscorify(),
+    input: [
+        '../../../../../yaml/xyz/openbmc_project/State/Decorator/Heartbeat.interface.yaml',
+    ],
+    output: ['Heartbeat.md'],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog,
+        '--command',
+        'markdown',
+        '--output',
+        meson.current_build_dir(),
+        '--tool',
+        sdbusplusplus_prog,
+        '--directory',
+        meson.current_source_dir() / '../../../../../yaml',
+        'xyz/openbmc_project/State/Decorator/Heartbeat',
     ],
     install: should_generate_markdown,
     install_dir: [inst_markdown_dir / sdbusplus_current_path],

--- a/yaml/xyz/openbmc_project/State/BMC/Redundancy.interface.yaml
+++ b/yaml/xyz/openbmc_project/State/BMC/Redundancy.interface.yaml
@@ -1,6 +1,5 @@
 description: >
-    This interface holds redundant BMC related information.  There would be
-    instance of this interface on each BMC.
+    This interface holds redundant BMC related information.
 
 properties:
     - name: Role
@@ -34,21 +33,6 @@ properties:
 
           This can only be changed on the active BMC and when power is off,
           otherwise it will throw the Unavailable error.
-    - name: FailoversPaused
-      type: boolean
-      flags:
-          - readonly
-      default: false
-      description: >
-          When redundancy is enabled, there may be periods when either failovers
-          are not allowed, such as in the middle of a code update, or won't work
-          because the passive BMC is temporarily offline, such as when the
-          passive BMC reboots. A timer would be put on how long redundancy could
-          still be considered enabled in this latter case in case the passive
-          BMC never comes back.  Redundancy is left enabled initially so as to
-          not trigger any intervention that could be necessary when redundancy
-          is lost just due to a BMC reboot.  Any time the passive BMC goes
-          offline a full file sync would be necessary when it comes back.
     - name: FailoversAllowed
       type: boolean
       flags:
@@ -59,6 +43,15 @@ properties:
           enabled, a failover may not be allowed because there are periods when
           doing a failover could cause issues, such as in the middle of a boot
           or code update.
+    - name: FailoverImminent
+      type: boolean
+      flags:
+          - readonly
+      default: false
+      description: >
+          There can be a grace period between a failover being requested and the
+          failover actually starting where this will be asserted to allow for
+          any preparation or tracing on the other BMC.
 
 enumerations:
     - name: Role
@@ -88,3 +81,14 @@ paths:
     - instance: /xyz/openbmc_project/state/bmc0
       description: >
           The BMC redundancy path.
+    - namespace: /xyz/openbmc_project/state
+      segments:
+          - name: BMC
+            description: >
+                The object representing _this_ BMC is always at bmc0.
+            value: bmc0
+          - name: SiblingBMC
+            description: >
+                The object representing _the sibling_ BMC is always at bmc1 in a
+                2 BMC system.
+            value: bmc1

--- a/yaml/xyz/openbmc_project/State/Decorator/Heartbeat.interface.yaml
+++ b/yaml/xyz/openbmc_project/State/Decorator/Heartbeat.interface.yaml
@@ -1,0 +1,11 @@
+description: >
+    Implement to show the status of a heartbeat indication, if it's considered
+    active or not.
+properties:
+    - name: Active
+      type: boolean
+      default: false
+      flags:
+          - readonly
+      description: >
+          If the heartbeat is active.


### PR DESCRIPTION
Changes necessary to move away from the State.Redundancy.Sibling interface to use individual interfaces:
1. A new interface for the heartbeat.
2. A new path entry constant in the State.Redundancy interface for when it represents the sibling on /xyz/openbmc_project/state/bmc1.

Also included:
1. Removed FailoversPaused as this is no longer used
2. Add FailoverImminent which will be necessary for failovers.