### PR TITLE
Add ACFPath to Resource dump entry interface

### DIFF
--- a/yaml/com/ibm/Dump/Create.interface.yaml
+++ b/yaml/com/ibm/Dump/Create.interface.yaml
@@ -28,6 +28,12 @@ enumerations:
             description: >
                 A unique id of failing hardware unit which is causing the dump.
                 The value should be a 32 bit unsigned integer.
+          - name: "ACFPath"
+            description: >
+                The absolute path to a targeted Access Control File (ACF)
+                used to trigger a specific host operation like resource
+                dump. The file is parsed by the BMC and sent to the host
+                via PLDM.
 
     - name: DumpType
       description: >

--- a/yaml/com/ibm/Dump/Entry/Resource.interface.yaml
+++ b/yaml/com/ibm/Dump/Entry/Resource.interface.yaml
@@ -46,6 +46,14 @@ properties:
           resource dump to indicate whether the request is successful or there
           is an error.
       default: Unknown
+    - name: ACFPath
+      type: string
+      description: >
+          The full path to the targeted Access Control File (ACF) used for
+          privileged operations such as resource dumps. The ACF content is
+          sent to the host via PLDM to trigger the intended operation.
+          This file is passed during the create request and retained in
+          the D-Bus entry so the PLDM responder can pick it up.
 
 enumerations:
     - name: HostResponse


### PR DESCRIPTION
This change adds a new D-Bus property `ACFPath` to the `com.ibm.Dump.Entry.Resource` interface to support targeted Access Control Files (ACFs) used in privileged host operations.