### PR TITLE
Added NotStarted value to Status property

### DIFF
--- a/yaml/xyz/openbmc_project/Common/Progress.interface.yaml
+++ b/yaml/xyz/openbmc_project/Common/Progress.interface.yaml
@@ -29,6 +29,9 @@ enumerations:
       description: >
           Status of the activity
       values:
+          - name: NotStarted
+            description: >
+                Requested operation is not started.
           - name: InProgress
             description: >
                 Requested operation is in progress.


### PR DESCRIPTION
This commit adds new value ‘NotSarted’ to Status property under
xyz.openbmc_project.Common.Progress interface to mark operation is not
started yet.