### PR TITLE
Changes to fix the CI failure

### DIFF
--- a/yaml/com/ibm/Dump/Create.interface.yaml
+++ b/yaml/com/ibm/Dump/Create.interface.yaml
@@ -30,10 +30,9 @@ enumerations:
                 The value should be a 32 bit unsigned integer.
           - name: "ACFPath"
             description: >
-                The absolute path to a targeted Access Control File (ACF)
-                used to trigger a specific host operation like resource
-                dump. The file is parsed by the BMC and sent to the host
-                via PLDM.
+                The absolute path to a targeted Access Control File (ACF) used
+                to trigger a specific host operation like resource dump. The
+                file is parsed by the BMC and sent to the host via PLDM.
 
     - name: DumpType
       description: >

--- a/yaml/com/ibm/Dump/Entry/Resource.interface.yaml
+++ b/yaml/com/ibm/Dump/Entry/Resource.interface.yaml
@@ -50,10 +50,10 @@ properties:
       type: string
       description: >
           The full path to the targeted Access Control File (ACF) used for
-          privileged operations such as resource dumps. The ACF content is
-          sent to the host via PLDM to trigger the intended operation.
-          This file is passed during the create request and retained in
-          the D-Bus entry so the PLDM responder can pick it up.
+          privileged operations such as resource dumps. The ACF content is sent
+          to the host via PLDM to trigger the intended operation. This file is
+          passed during the create request and retained in the D-Bus entry so
+          the PLDM responder can pick it up.
 
 enumerations:
     - name: HostResponse


### PR DESCRIPTION
Changed the indentation to fix the CI failure.

Gerrit link: https://gerrit.openbmc.org/c/openbmc/phosphor-dbus-interfaces/+/82108