### PR TITLE
State: Add min and max to Redundancy interface

### DIFF
--- a/yaml/xyz/openbmc_project/State/BMC/Redundancy.interface.yaml
+++ b/yaml/xyz/openbmc_project/State/BMC/Redundancy.interface.yaml
@@ -59,6 +59,21 @@ properties:
           - readonly
       description: >
           Indicates that a failover is in progress.
+    - name: RedundancyMinimum
+      type: size
+      flags:
+          - readonly
+      default: 2
+      description: >
+          The minimum number of BMC objects needed for redundancy to be enabled.
+    - name: RedundancyMaximum
+      type: size
+      flags:
+          - readonly
+      default: maxint
+      description: >
+          The maximum number of BMC objects allowed to be part of the redundancy
+          group.
 
 enumerations:
     - name: Role


### PR DESCRIPTION
Cherry-picked upstream merged commit: https://gerrit.openbmc.org/c/openbmc/phosphor-dbus-interfaces/+/82465

Add RedundancyMinimum and RedundancyMaximum properties to the Redundancy interface to specify how many BMC objects can be part of the redundant group.

These properties can be utilized by bmcweb to support the Redundancy property of the Manager Redfish schema.[1] The Redfish definition for Redundancy requires minimum to be reported.[2]

[1] http://redfish.dmtf.org/schemas/v1/Manager.v1_22_0.json#/definitions/Manager
[2] http://redfish.dmtf.org/schemas/v1/Redundancy.v1_5_0.json#/definitions/Redundancy

Change-Id: I02db0fb7259b2922711fb56cdb1455185d4a609a