### PR TITLE
Common.Progress: add new value to OperationStatus

### DIFF
--- a/yaml/xyz/openbmc_project/Common/Progress.interface.yaml
+++ b/yaml/xyz/openbmc_project/Common/Progress.interface.yaml
@@ -8,7 +8,7 @@ description: >
 properties:
     - name: Status
       type: enum[self.OperationStatus]
-      default: InProgress
+      default: NotStarted
       description: >
           Indicate the state of the operation, whether in progress, completed
           aborted or failed. The default should be InProgress during the


### PR DESCRIPTION
To capture state of operation where it has not yet started, new enum value ‘NotStarted’ has been added to OperationStatus and default value is set as NotStarted to indicate operation is not yet started.

Cherry pick from
```
https://gerrit.openbmc.org/c/openbmc/phosphor-dbus-interfaces/+/82761
```

Change-Id: I1d52ca4debd87153fb4e15a2568249749051c80e