### PR TITLE
inventory: Add Position decorator interface

### DIFF
--- a/gen/xyz/openbmc_project/Inventory/Decorator/Position/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Decorator/Position/meson.build
@@ -1,0 +1,40 @@
+# Generated file; do not modify.
+
+sdbusplus_current_path = 'xyz/openbmc_project/Inventory/Decorator/Position'
+
+generated_sources += custom_target(
+    'xyz/openbmc_project/Inventory/Decorator/Position__cpp'.underscorify(),
+    input: [
+        '../../../../../../yaml/xyz/openbmc_project/Inventory/Decorator/Position.interface.yaml',
+    ],
+    output: [
+        'common.hpp',
+        'server.hpp',
+        'server.cpp',
+        'aserver.hpp',
+        'client.hpp',
+    ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog,
+        '--command',
+        'cpp',
+        '--output',
+        meson.current_build_dir(),
+        '--tool',
+        sdbusplusplus_prog,
+        '--directory',
+        meson.current_source_dir() / '../../../../../../yaml',
+        'xyz/openbmc_project/Inventory/Decorator/Position',
+    ],
+    install: should_generate_cpp,
+    install_dir: [
+        get_option('includedir') / sdbusplus_current_path,
+        get_option('includedir') / sdbusplus_current_path,
+        false,
+        get_option('includedir') / sdbusplus_current_path,
+        get_option('includedir') / sdbusplus_current_path,
+    ],
+    build_by_default: should_generate_cpp,
+)
+

--- a/gen/xyz/openbmc_project/Inventory/Decorator/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Decorator/meson.build
@@ -11,6 +11,7 @@ subdir('LocationCode')
 subdir('ManagedHost')
 subdir('ManufacturerExt')
 subdir('MeetsMinimumShipLevel')
+subdir('Position')
 subdir('Replaceable')
 subdir('Revision')
 subdir('Slot')
@@ -303,6 +304,30 @@ generated_markdown += custom_target(
         '--directory',
         meson.current_source_dir() / '../../../../../yaml',
         'xyz/openbmc_project/Inventory/Decorator/MeetsMinimumShipLevel',
+    ],
+    install: should_generate_markdown,
+    install_dir: [inst_markdown_dir / sdbusplus_current_path],
+    build_by_default: should_generate_markdown,
+)
+
+generated_markdown += custom_target(
+    'xyz/openbmc_project/Inventory/Decorator/Position__markdown'.underscorify(),
+    input: [
+        '../../../../../yaml/xyz/openbmc_project/Inventory/Decorator/Position.interface.yaml',
+    ],
+    output: ['Position.md'],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog,
+        '--command',
+        'markdown',
+        '--output',
+        meson.current_build_dir(),
+        '--tool',
+        sdbusplusplus_prog,
+        '--directory',
+        meson.current_source_dir() / '../../../../../yaml',
+        'xyz/openbmc_project/Inventory/Decorator/Position',
     ],
     install: should_generate_markdown,
     install_dir: [inst_markdown_dir / sdbusplus_current_path],

--- a/yaml/xyz/openbmc_project/Inventory/Decorator/Position.interface.yaml
+++ b/yaml/xyz/openbmc_project/Inventory/Decorator/Position.interface.yaml
@@ -1,0 +1,13 @@
+description: >
+    Holds the position of an inventory item when it's necessary to distinguish
+    it from other inventory items of the same type.
+
+    Use this interface when the the object in question does not represent a
+    literal slot (a narrow opening) or plug into one. If it does, then prefer
+    the slot decorator interface.
+properties:
+    - name: Position
+      type: size
+      default: maxint
+      description: >
+          The position.


### PR DESCRIPTION
This decorator interface is used for holding the position of an inventory item when there are multiple of the same type.

The alternative interface is Decorator.Slot.  The definition of a slot, as applicable to this context, is 'a narrow opening or groove'.  An example in a computer is a PCIe slot, so the Slot interface would be appropriate there.

In other situations for ordering things that don't fit the slot definition this Position interface would be more appropriate.

In the long run it probably doesn't matter that much as long as it's consistent in the D-bus objects that the code looking for the interface uses.

Change-Id: I1fbf9763c3854f5092081a8780d2a56ef0c23c68