### PR TITLE
LDAP: Add AllowReadOnlyAccessToAllLDAPUsers property

### DIFF
--- a/xyz/openbmc_project/User/PrivilegeMapper.interface.yaml
+++ b/xyz/openbmc_project/User/PrivilegeMapper.interface.yaml
@@ -44,3 +44,11 @@ methods:
           - xyz.openbmc_project.Common.Error.InternalFailure
           - xyz.openbmc_project.Common.Error.InvalidArgument
           - xyz.openbmc_project.User.Common.Error.PrivilegeMappingExists
+properties:
+    - name: AllowReadOnlyAccessToAllLDAPUsers
+      type: boolean
+      default: true
+      description: >
+          This property indicates whether to allow default readonly privilege
+          for LDAP users when respective privilege role map is not configured
+          for LDAP users.


### PR DESCRIPTION
This commit adds AllowReadOnlyAccessToAllLDAPUsers property under
PrivilegeMapper interface.

This property indicates whether to allow default readonly privilege for LDAP
users when role map is not configured for the LDAP user.
by default this property value set to true and set/get operations performed through
corresponding redfish property.