### PR TITLE
Failover: Add requester to StartFailover method

### DIFF
--- a/yaml/xyz/openbmc_project/Control/Failover.interface.yaml
+++ b/yaml/xyz/openbmc_project/Control/Failover.interface.yaml
@@ -9,6 +9,10 @@ methods:
       description: >
           Starts a failover operation.
       parameters:
+          - name: Requester
+            type: enum[self.Requester]
+            description: >
+                Identifies who's requesting the failover
           - name: Options
             type: dict[string, variant[boolean]]
             description: >
@@ -28,6 +32,22 @@ properties:
           Indicates that a failover is in progress.
 
 enumerations:
+    - name: Requester
+      description: >
+          Who is requesting the failover.
+      values:
+          - name: Host
+            description: >
+                The host is requesting the failover.
+          - name: Redfish
+            description: >
+                A Redfish client is requesting the failover.
+          - name: SystemConfig
+            description: >
+                A system config checker on the BMC is requesting the failover.
+          - name: Tool
+            description: >
+                A command line tool is requesting the failover.
     - name: Options
       description: >
           Available options for starting the failover.


### PR DESCRIPTION
Add a 'Requester' parameter to the StartFailover method so that the source of the failover can be known.  It is an enum to limit the scope of what it can be.

Change-Id: I9122ed2b7fd1040e8ddb2c5c840b68c8a18a272f