### PR TITLE
State:RBMC: Add ReasonsForNoRedundancy property

### DIFF
--- a/yaml/xyz/openbmc_project/State/BMC/Redundancy.interface.yaml
+++ b/yaml/xyz/openbmc_project/State/BMC/Redundancy.interface.yaml
@@ -74,6 +74,13 @@ properties:
       description: >
           The maximum number of BMC objects allowed to be part of the redundancy
           group.
+    - name: ReasonsForNoRedundancy
+      type: set[enum[self.ReasonForNoRedundancy]]
+      flags:
+          - readonly
+      description: >
+          If redundancy cannot be enabled and RedundancyEnabled is false, this
+          contains the reasons why.
 
 enumerations:
     - name: Role
@@ -92,6 +99,48 @@ enumerations:
                 The role is for the passive BMC, which is the opposite of the
                 active BMC.  It may not have all services running, and would
                 require a failover to become active.
+
+    - name: ReasonForNoRedundancy
+      description: >
+          The possible reasons why redundancy can't be enabled.
+      values:
+          - name: BMCNotActive
+            description: >
+                The BMC doesn't have the Active role.
+          - name: ManuallyDisabled
+            description: >
+                Redundancy has been manually disabled.
+          - name: SiblingMissing
+            description: >
+                The sibling BMC is missing.
+          - name: SiblingNotAlive
+            description: >
+                The sibling BMC is not alive.
+          - name: SiblingNotProvisioned
+            description: >
+                The sibling BMC is not provisioned.
+          - name: SiblingNotPassive
+            description: >
+                The sibling BMC does not have the Passive role.
+          - name: SiblingNotAtReady
+            description: >
+                The sibling BMC is not at the Ready state.
+          - name: CodeVersionMismatch
+            description: >
+                The BMCs have different versions of code.
+          - name: SystemHWConfigIssue
+            description: >
+                The non-BMC hardware configuration does not allow redundancy.
+                Something is missing, broken, or deconfigured.
+          - name: RedundancyOffAtRuntimeStart
+            description: >
+                Redundancy wasn't already enabled at the start of host runtime.
+          - name: NetworkError
+            description: >
+                There is a network error between the BMCs.
+          - name: DataSyncFailed
+            description: >
+                Data sync between the BMCs is failing.
 
 signals:
     - name: Heartbeat


### PR DESCRIPTION
When BMC redundancy cannot be enabled, this property contains the reasons why. Before the code that determines redundancy runs, this property will be empty.

The long term plan is to make this available in Redfish.

Change-Id: I28bafa6a4bdd4b671dc730ebe3adc48b44d0d1d3