### PR TITLE
1120: Add UEFI SecureBoot Setting related interfaces

### DIFF
--- a/gen/xyz/openbmc_project/BIOSConfig/SecureBoot/meson.build
+++ b/gen/xyz/openbmc_project/BIOSConfig/SecureBoot/meson.build
@@ -1,0 +1,40 @@
+# Generated file; do not modify.
+
+sdbusplus_current_path = 'xyz/openbmc_project/BIOSConfig/SecureBoot'
+
+generated_sources += custom_target(
+    'xyz/openbmc_project/BIOSConfig/SecureBoot__cpp'.underscorify(),
+    input: [
+        '../../../../../yaml/xyz/openbmc_project/BIOSConfig/SecureBoot.interface.yaml',
+    ],
+    output: [
+        'common.hpp',
+        'server.hpp',
+        'server.cpp',
+        'aserver.hpp',
+        'client.hpp',
+    ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog,
+        '--command',
+        'cpp',
+        '--output',
+        meson.current_build_dir(),
+        '--tool',
+        sdbusplusplus_prog,
+        '--directory',
+        meson.current_source_dir() / '../../../../../yaml',
+        'xyz/openbmc_project/BIOSConfig/SecureBoot',
+    ],
+    install: should_generate_cpp,
+    install_dir: [
+        get_option('includedir') / sdbusplus_current_path,
+        get_option('includedir') / sdbusplus_current_path,
+        false,
+        get_option('includedir') / sdbusplus_current_path,
+        get_option('includedir') / sdbusplus_current_path,
+    ],
+    build_by_default: should_generate_cpp,
+)
+

--- a/gen/xyz/openbmc_project/BIOSConfig/meson.build
+++ b/gen/xyz/openbmc_project/BIOSConfig/meson.build
@@ -2,6 +2,7 @@
 subdir('Common')
 subdir('Manager')
 subdir('Password')
+subdir('SecureBoot')
 
 sdbusplus_current_path = 'xyz/openbmc_project/BIOSConfig'
 
@@ -71,6 +72,30 @@ generated_markdown += custom_target(
         '--directory',
         meson.current_source_dir() / '../../../../yaml',
         'xyz/openbmc_project/BIOSConfig/Password',
+    ],
+    install: should_generate_markdown,
+    install_dir: [inst_markdown_dir / sdbusplus_current_path],
+    build_by_default: should_generate_markdown,
+)
+
+generated_markdown += custom_target(
+    'xyz/openbmc_project/BIOSConfig/SecureBoot__markdown'.underscorify(),
+    input: [
+        '../../../../yaml/xyz/openbmc_project/BIOSConfig/SecureBoot.interface.yaml',
+    ],
+    output: ['SecureBoot.md'],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog,
+        '--command',
+        'markdown',
+        '--output',
+        meson.current_build_dir(),
+        '--tool',
+        sdbusplusplus_prog,
+        '--directory',
+        meson.current_source_dir() / '../../../../yaml',
+        'xyz/openbmc_project/BIOSConfig/SecureBoot',
     ],
     install: should_generate_markdown,
     install_dir: [inst_markdown_dir / sdbusplus_current_path],

--- a/yaml/xyz/openbmc_project/BIOSConfig/SecureBoot.interface.yaml
+++ b/yaml/xyz/openbmc_project/BIOSConfig/SecureBoot.interface.yaml
@@ -1,0 +1,59 @@
+description: >
+    UEFI Secure Boot information and represents properties for managing the UEFI
+    Secure Boot functionality of a system.
+
+properties:
+    - name: CurrentBoot
+      type: enum[self.CurrentBootType]
+      description: >
+          The UEFI Secure Boot state during the current boot cycle.
+      default: Unknown
+
+    - name: PendingEnable
+      type: boolean
+      description: >
+          An indication of whether the UEFI Secure Boot takes effect on next
+          boot.
+
+    - name: Mode
+      type: enum[self.ModeType]
+      description: >
+          The current UEFI Secure Boot Mode.
+      default: Unknown
+
+enumerations:
+    - name: CurrentBootType
+      description: >
+          Secure Boot Current Boot Type.
+      values:
+          - name: Unknown
+            description: >
+                UEFI Secure Boot is currently unknown.
+          - name: Enabled
+            description: >
+                UEFI Secure Boot is currently enabled.
+          - name: Disabled
+            description: >
+                UEFI Secure Boot is currently disabled.
+
+    - name: ModeType
+      description: >
+          Secure Boot Mode Type. UEFI Secure Boot Modes are defined in UEFI
+          Specification -
+          https://uefi.org/specs/UEFI/2.10/32_Secure_Boot_and_Driver_Signing.html#secure-boot-modes
+      values:
+          - name: Unknown
+            description: >
+                UEFI Secure Boot is currently unknown.
+          - name: Setup
+            description: >
+                UEFI Secure Boot is currently in Setup Mode.
+          - name: User
+            description: >
+                UEFI Secure Boot is currently in User Mode.
+          - name: Audit
+            description: >
+                UEFI Secure Boot is currently in Audit Mode.
+          - name: Deployed
+            description: >
+                UEFI Secure Boot is currently in Deployed Mode.


### PR DESCRIPTION
#### Add UEFI SecureBoot Setting related interfaces
```
Redfish added schema for SecureBoot, which contains UEFI Secure Boot
related information and represents properties for managing the UEFI
Secure Boot functionality of a system. It would be useful to add
remote UEFI secure boot configuration support which provides unified
interface for remote uefi secure boot configuration in data centers,
and provide a generic implementation for the remote management of
uefi secure boot.

Redfish Schema -
https://redfish.dmtf.org/schemas/v1/SecureBoot.v1_1_2.json

BIOSConfig.SecureBoot exposes three properties:
1) Enable: An indication of whether UEFI Secure Boot is enabled.
2) Current Boot: An indication of UEFI Secure Boot state during the
   current boot cycle
3) Mode: Indicates the current UEFI Secure Boot mode, as defined in
   the UEFI Specification.

Change-Id: I1a345c2efcdd42be9920b509649621157b88775a
Signed-off-by: Prithvi Pai <ppai@nvidia.com>
```