### PR TITLE
1210: secret: Update the secret baseline file & Add UEFI SecureBoot Setting related interfaces

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-10-17T10:22:59Z",
+  "generated_at": "2025-11-04T05:14:57Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -100,7 +100,7 @@
         "hashed_secret": "3b4d89f26594b275f7572bb14fed31ac4c9b5981",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 33,
+        "line_number": 34,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -108,7 +108,7 @@
         "hashed_secret": "32cae99c56c08352b024c5143a153260ff0732de",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 57,
+        "line_number": 58,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -116,7 +116,15 @@
         "hashed_secret": "287aa7ca33e2caf581397144b4d99ce2bac77a31",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 73,
+        "line_number": 74,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "36f1271c7f90ee47258dc98bab74b4ae006fb7e9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 82,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }

--- a/gen/xyz/openbmc_project/BIOSConfig/SecureBoot/meson.build
+++ b/gen/xyz/openbmc_project/BIOSConfig/SecureBoot/meson.build
@@ -1,0 +1,40 @@
+# Generated file; do not modify.
+
+sdbusplus_current_path = 'xyz/openbmc_project/BIOSConfig/SecureBoot'
+
+generated_sources += custom_target(
+    'xyz/openbmc_project/BIOSConfig/SecureBoot__cpp'.underscorify(),
+    input: [
+        '../../../../../yaml/xyz/openbmc_project/BIOSConfig/SecureBoot.interface.yaml',
+    ],
+    output: [
+        'common.hpp',
+        'server.hpp',
+        'server.cpp',
+        'aserver.hpp',
+        'client.hpp',
+    ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog,
+        '--command',
+        'cpp',
+        '--output',
+        meson.current_build_dir(),
+        '--tool',
+        sdbusplusplus_prog,
+        '--directory',
+        meson.current_source_dir() / '../../../../../yaml',
+        'xyz/openbmc_project/BIOSConfig/SecureBoot',
+    ],
+    install: should_generate_cpp,
+    install_dir: [
+        get_option('includedir') / sdbusplus_current_path,
+        get_option('includedir') / sdbusplus_current_path,
+        false,
+        get_option('includedir') / sdbusplus_current_path,
+        get_option('includedir') / sdbusplus_current_path,
+    ],
+    build_by_default: should_generate_cpp,
+)
+

--- a/gen/xyz/openbmc_project/BIOSConfig/meson.build
+++ b/gen/xyz/openbmc_project/BIOSConfig/meson.build
@@ -2,6 +2,7 @@
 subdir('Common')
 subdir('Manager')
 subdir('Password')
+subdir('SecureBoot')
 
 sdbusplus_current_path = 'xyz/openbmc_project/BIOSConfig'
 
@@ -71,6 +72,30 @@ generated_markdown += custom_target(
         '--directory',
         meson.current_source_dir() / '../../../../yaml',
         'xyz/openbmc_project/BIOSConfig/Password',
+    ],
+    install: should_generate_markdown,
+    install_dir: [inst_markdown_dir / sdbusplus_current_path],
+    build_by_default: should_generate_markdown,
+)
+
+generated_markdown += custom_target(
+    'xyz/openbmc_project/BIOSConfig/SecureBoot__markdown'.underscorify(),
+    input: [
+        '../../../../yaml/xyz/openbmc_project/BIOSConfig/SecureBoot.interface.yaml',
+    ],
+    output: ['SecureBoot.md'],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog,
+        '--command',
+        'markdown',
+        '--output',
+        meson.current_build_dir(),
+        '--tool',
+        sdbusplusplus_prog,
+        '--directory',
+        meson.current_source_dir() / '../../../../yaml',
+        'xyz/openbmc_project/BIOSConfig/SecureBoot',
     ],
     install: should_generate_markdown,
     install_dir: [inst_markdown_dir / sdbusplus_current_path],

--- a/yaml/xyz/openbmc_project/BIOSConfig/SecureBoot.interface.yaml
+++ b/yaml/xyz/openbmc_project/BIOSConfig/SecureBoot.interface.yaml
@@ -1,0 +1,59 @@
+description: >
+    UEFI Secure Boot information and represents properties for managing the UEFI
+    Secure Boot functionality of a system.
+
+properties:
+    - name: CurrentBoot
+      type: enum[self.CurrentBootType]
+      description: >
+          The UEFI Secure Boot state during the current boot cycle.
+      default: Unknown
+
+    - name: PendingEnable
+      type: boolean
+      description: >
+          An indication of whether the UEFI Secure Boot takes effect on next
+          boot.
+
+    - name: Mode
+      type: enum[self.ModeType]
+      description: >
+          The current UEFI Secure Boot Mode.
+      default: Unknown
+
+enumerations:
+    - name: CurrentBootType
+      description: >
+          Secure Boot Current Boot Type.
+      values:
+          - name: Unknown
+            description: >
+                UEFI Secure Boot is currently unknown.
+          - name: Enabled
+            description: >
+                UEFI Secure Boot is currently enabled.
+          - name: Disabled
+            description: >
+                UEFI Secure Boot is currently disabled.
+
+    - name: ModeType
+      description: >
+          Secure Boot Mode Type. UEFI Secure Boot Modes are defined in UEFI
+          Specification -
+          https://uefi.org/specs/UEFI/2.10/32_Secure_Boot_and_Driver_Signing.html#secure-boot-modes
+      values:
+          - name: Unknown
+            description: >
+                UEFI Secure Boot is currently unknown.
+          - name: Setup
+            description: >
+                UEFI Secure Boot is currently in Setup Mode.
+          - name: User
+            description: >
+                UEFI Secure Boot is currently in User Mode.
+          - name: Audit
+            description: >
+                UEFI Secure Boot is currently in Audit Mode.
+          - name: Deployed
+            description: >
+                UEFI Secure Boot is currently in Deployed Mode.


### PR DESCRIPTION
#### secret: Update the secret baseline file
```
Signed-off-by: Manojkiran Eda <manojkiran.eda@gmail.com>
```
#### Add UEFI SecureBoot Setting related interfaces
```
Redfish added schema for SecureBoot, which contains UEFI Secure Boot
related information and represents properties for managing the UEFI
Secure Boot functionality of a system. It would be useful to add
remote UEFI secure boot configuration support which provides unified
interface for remote uefi secure boot configuration in data centers,
and provide a generic implementation for the remote management of
uefi secure boot.

Redfish Schema -
https://redfish.dmtf.org/schemas/v1/SecureBoot.v1_1_2.json

BIOSConfig.SecureBoot exposes three properties:
1) Enable: An indication of whether UEFI Secure Boot is enabled.
2) Current Boot: An indication of UEFI Secure Boot state during the
   current boot cycle
3) Mode: Indicates the current UEFI Secure Boot mode, as defined in
   the UEFI Specification.

Change-Id: I1a345c2efcdd42be9920b509649621157b88775a
Signed-off-by: Prithvi Pai <ppai@nvidia.com>
```