### PR TITLE
Control: Add SideBandBus interface

### DIFF
--- a/gen/xyz/openbmc_project/Control/SideBandBus/meson.build
+++ b/gen/xyz/openbmc_project/Control/SideBandBus/meson.build
@@ -1,0 +1,40 @@
+# Generated file; do not modify.
+
+sdbusplus_current_path = 'xyz/openbmc_project/Control/SideBandBus'
+
+generated_sources += custom_target(
+    'xyz/openbmc_project/Control/SideBandBus__cpp'.underscorify(),
+    input: [
+        '../../../../../yaml/xyz/openbmc_project/Control/SideBandBus.interface.yaml',
+    ],
+    output: [
+        'common.hpp',
+        'server.hpp',
+        'server.cpp',
+        'aserver.hpp',
+        'client.hpp',
+    ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog,
+        '--command',
+        'cpp',
+        '--output',
+        meson.current_build_dir(),
+        '--tool',
+        sdbusplusplus_prog,
+        '--directory',
+        meson.current_source_dir() / '../../../../../yaml',
+        'xyz/openbmc_project/Control/SideBandBus',
+    ],
+    install: should_generate_cpp,
+    install_dir: [
+        get_option('includedir') / sdbusplus_current_path,
+        get_option('includedir') / sdbusplus_current_path,
+        false,
+        get_option('includedir') / sdbusplus_current_path,
+        get_option('includedir') / sdbusplus_current_path,
+    ],
+    build_by_default: should_generate_cpp,
+)
+

--- a/gen/xyz/openbmc_project/Control/meson.build
+++ b/gen/xyz/openbmc_project/Control/meson.build
@@ -17,6 +17,7 @@ subdir('PowerSupplyRedundancy')
 subdir('Processor')
 subdir('Security')
 subdir('Service')
+subdir('SideBandBus')
 subdir('SyncBMCData')
 subdir('TPM')
 subdir('ThermalMode')
@@ -328,6 +329,30 @@ generated_markdown += custom_target(
         '--directory',
         meson.current_source_dir() / '../../../../yaml',
         'xyz/openbmc_project/Control/PowerSupplyRedundancy',
+    ],
+    install: should_generate_markdown,
+    install_dir: [inst_markdown_dir / sdbusplus_current_path],
+    build_by_default: should_generate_markdown,
+)
+
+generated_markdown += custom_target(
+    'xyz/openbmc_project/Control/SideBandBus__markdown'.underscorify(),
+    input: [
+        '../../../../yaml/xyz/openbmc_project/Control/SideBandBus.interface.yaml',
+    ],
+    output: ['SideBandBus.md'],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog,
+        '--command',
+        'markdown',
+        '--output',
+        meson.current_build_dir(),
+        '--tool',
+        sdbusplusplus_prog,
+        '--directory',
+        meson.current_source_dir() / '../../../../yaml',
+        'xyz/openbmc_project/Control/SideBandBus',
     ],
     install: should_generate_markdown,
     install_dir: [inst_markdown_dir / sdbusplus_current_path],

--- a/yaml/xyz/openbmc_project/Control/SideBandBus.interface.yaml
+++ b/yaml/xyz/openbmc_project/Control/SideBandBus.interface.yaml
@@ -1,0 +1,35 @@
+description: >
+    Interface for controlling ownership of a hardware sideband bus from the BMC.
+    In redundant BMC systems, the service processor accesses devices via a
+    shared sideband bus that only one BMC can drive at a time, this interface
+    lets BMC software acquire and release that ownership and it's concrete
+    implementation can be system architecture specific.
+
+methods:
+    - name: Acquire
+      description: >
+          Acquire ownership of the sideband bus.
+      parameters:
+          - name: Options
+            type: dict[string, variant[boolean]]
+            description: >
+                Additional options. The key is the string version of the
+                Options.
+      errors:
+          - xyz.openbmc_project.Common.Error.Unavailable
+          - xyz.openbmc_project.Common.Error.InvalidArgument
+          - xyz.openbmc_project.Common.Device.Error.WriteFailure
+
+enumerations:
+    - name: AcquireOptions
+      description: >
+          Available options to acquire ownership of the bus.
+      values:
+          - name: Force
+            description: >
+                A boolean option to force the bus ownership.
+
+paths:
+    - instance: /xyz/openbmc_project/control/sideband_bus
+      description: >
+          The object path for the sideband bus control.


### PR DESCRIPTION
- This commit introduces a new D-Bus interface 'xyz.openbmc_project.Control.SideBandBus' to provide a mechanism for user space applications to manage ownership of a shared sideband hardware bus.

- In OpenBMC systems, the service processor accesses devices through such sideband buses. When more than one controller (for example, redundant BMCs) can drive the same bus, the system needs a way to decide which side currently owns it. This interface defines a standard way to request ownership so that applications can safely control bus access without relying on platform specific behavior.

This interface provides:
 - Provides 'Acquire' methods for managing bus ownership.
 
Upstream PR: https://gerrit.openbmc.org/c/openbmc/phosphor-dbus-interfaces/+/85398
Regarding the `owned` property, it is intentionally not included at this stage. Since it is currently used only for debugging, we want to finalize the correct backend approach especially considering sled re-integration use cases to avoid a partial implementation.