### PR TITLE
State:RBMC: Add new ReasonForNoRedundancy

### DIFF
--- a/yaml/xyz/openbmc_project/State/BMC/Redundancy.interface.yaml
+++ b/yaml/xyz/openbmc_project/State/BMC/Redundancy.interface.yaml
@@ -125,6 +125,10 @@ enumerations:
           - name: SiblingNotAtReady
             description: >
                 The sibling BMC is not at the Ready state.
+          - name: SiblingCannotBeActive
+            description: >
+                There is something wrong with the sibling BMC such that it can
+                never be active.
           - name: CodeVersionMismatch
             description: >
                 The BMCs have different versions of code.


### PR DESCRIPTION
This new SiblingCannotBeActive reason indicates that the sibling BMC has some condition such that it should never be active and so redundancy can't be enabled.

Change-Id: I0efc3082d8dee55789c1a50bde78b8f31c0daf2b