### PR TITLE
1210: Error Handling:Add error handling for unprovisioned BMC in provision-peer (#201)

### DIFF
--- a/yaml/xyz/openbmc_project/Provisioning/Provisioning.interface.yaml
+++ b/yaml/xyz/openbmc_project/Provisioning/Provisioning.interface.yaml
@@ -28,6 +28,8 @@ methods:
             type: string
             description: >
                 Identifier of the peer BMC to be provisioned.
+      errors:
+          - xyz.openbmc_project.Common.Error.NotAllowed
 
 signals:
     - name: PeerProvisioned


### PR DESCRIPTION
#### Error Handling:Add error handling for unprovisioned BMC in provision-peer (#201)
```
If the current BMC is not provisioned, it cannot provision any other BMCs.
This change ensures that if a client calls the provisionPeer method on an
unprovisioned BMC, an InsufficientPermission error is returned. This
provides clear feedback and prevents invalid operations.

Signed-off-by: Abhilash Raju <abhilash.kollam@gmail.com>```