### PR TITLE
State: Add functional minimum to Redundancy interface

### DIFF
--- a/yaml/xyz/openbmc_project/State/BMC/Redundancy.interface.yaml
+++ b/yaml/xyz/openbmc_project/State/BMC/Redundancy.interface.yaml
@@ -74,6 +74,14 @@ properties:
       description: >
           The maximum number of BMC objects allowed to be part of the redundancy
           group.
+    - name: FunctionalMinimum
+      type: size
+      flags:
+          - readonly
+      default: 1
+      description: >
+          The minimum number of BMC objects needed for the redundancy group to
+          remain functional.
     - name: ReasonsForNoRedundancy
       type: set[enum[self.ReasonForNoRedundancy]]
       flags:


### PR DESCRIPTION
Cherry-pick of upstream merged commit: https://gerrit.openbmc.org/c/openbmc/phosphor-dbus-interfaces/+/86960

Add FunctionalMinimum property to the Redundancy interface to provide a distinction between the minimum needed for fault tolerance and the minimum needed for functioning.

This new property can be utilized by bmcweb to support the Redundancy property of the Manager Redfish schema.[1] The Redfish definition for Redundancy has two properties for reporting minimums.[2] Redfish Release 2025.4 added the second minimum property.[3]

[1] https://redfish.dmtf.org/schemas/v1/Manager.v1_24_0.json
[2] https://redfish.dmtf.org/schemas/v1/Redundancy.v1_7_0.json
[3] https://www.dmtf.org/sites/default/files/Redfish_Release_2025.4_Overview.pdf

Change-Id: Iac26866ba7bd06b2270145a292984f3dd4fcfb8c