### PR TITLE
IBM : Add method to clear FRU VPD

### DIFF
--- a/yaml/com/ibm/VPD/Manager.interface.yaml
+++ b/yaml/com/ibm/VPD/Manager.interface.yaml
@@ -136,3 +136,8 @@ methods:
                 Dbus path of the FRU whose VPD needs to be collected.
       errors:
           - xyz.openbmc_project.Common.Error.InvalidArgument
+
+    - name: DeleteAllFRUVPD
+      description: >
+          Method to clear all FRU VPD other than the system VPD from PIM
+          persisted path.


### PR DESCRIPTION
This commit adds a method to the VPD.Manager interface to delete all FRU VPD other than system VPD, from the PIM persisted path.

Persisted VPD may become stale due to hardware reconfiguration or when FRUs are no longer accessible. In such cases, clearing these entries ensures the inventory can be repopulated with valid data.

Change-Id: If20ca240e25bc06c2ffa2e231ed0e6c1f30e3c5b