### PR TITLE
IBM : Add method to validate redundant EEPROM

### DIFF
--- a/yaml/com/ibm/VPD/Manager.interface.yaml
+++ b/yaml/com/ibm/VPD/Manager.interface.yaml
@@ -141,3 +141,21 @@ methods:
       description: >
           Method to clear all FRU VPD other than the system VPD from PIM
           persisted path.
+
+    - name: ValidateRedundantEEPROM
+      description: >
+          Method to check whether the VPD of the given EEPROM matches that of
+          its redundant EEPROM, whose path is specified in the system
+          configuration JSON.
+      parameters:
+          - name: path
+            type: string
+            description: >
+                EEPROM path of the FRU.
+      returns:
+          - name: comparisonResult
+            type: boolean
+            description: >
+                True if both EEPROMs contain identical VPD, false otherwise.
+      errors:
+          - xyz.openbmc_project.Common.Error.InvalidArgument


### PR DESCRIPTION
This commit adds a method to the VPD.Manager interface to check whether the VPD of a given EEPROM matches that of its redundant EEPROM, whose path is specified in the system configuration JSON.

Some FRUs store a redundant VPD copy on an alternate EEPROM, and certain workflows need to verify whether both copies are identical.

Change-Id: I35e02cc54e745b70c46ddaecfbae215ba7d91042