### PR TITLE
State:RBMC: Add FailoversNotAllowedReason

### DIFF
--- a/yaml/xyz/openbmc_project/State/BMC/Redundancy.interface.yaml
+++ b/yaml/xyz/openbmc_project/State/BMC/Redundancy.interface.yaml
@@ -89,6 +89,14 @@ properties:
       description: >
           If redundancy cannot be enabled and RedundancyEnabled is false, this
           contains the reasons why.
+    - name: FailoversNotAllowedReason
+      type: enum[self.FailoversNotAllowedReason]
+      flags:
+          - readonly
+      default: "None"
+      description: >
+          If failovers aren't allowed and FailoversAllowed is false, this
+          contains the reason why.
 
 enumerations:
     - name: Role
@@ -153,6 +161,27 @@ enumerations:
           - name: DataSyncFailed
             description: >
                 Data sync between the BMCs is failing.
+
+    - name: FailoversNotAllowedReason
+      description: >
+          The possible reasons why failovers aren't allowed.
+      values:
+          - name: None
+            description: >
+                There is no reason.
+          - name: NoRedundancy
+            description: >
+                Redundancy is not enabled.
+          - name: FailoverInProgress
+            description: >
+                A failover is already in progress.
+          - name: FullSyncNotComplete
+            description: >
+                A full data sync is not complete.
+          - name: WrongSystemState
+            description: >
+                The system is not in the proper state, e.g. not off or at
+                runtime.
 
 signals:
     - name: Heartbeat


### PR DESCRIPTION
When FailoversAllowed is false, this property contains the reason why.

Similar to DisabledRedundancyReasons, this will be populated in Redfish as an (probably OEM) message in the Conditions property which is under the Status property in the Redundancy schema.

This is also used for debug on the BMC and will be included in BMC dumps.

Change-Id: I1c8949d944d6f42eb6f4d8a3376d8bc78bdac8d1