### PR TITLE
State:RBMC: Change ReasonsForNoRed to an array

### DIFF
--- a/yaml/xyz/openbmc_project/State/BMC/Redundancy.interface.yaml
+++ b/yaml/xyz/openbmc_project/State/BMC/Redundancy.interface.yaml
@@ -83,7 +83,7 @@ properties:
           The minimum number of BMC objects needed for the redundancy group to
           remain functional.
     - name: ReasonsForNoRedundancy
-      type: set[enum[self.ReasonForNoRedundancy]]
+      type: array[enum[self.ReasonForNoRedundancy]]
       flags:
           - readonly
       description: >


### PR DESCRIPTION
The values in the ReasonsForNoRedundancy property are inserted in order of importance, so change the property to an array from a set so that order is maintained and not just sorted alphabetically.

Change-Id: I2f1aea6c4765870733d3ee3c572dcd2b6effafa7