### PR TITLE
com.ibm: Add SPPE dump type

### DIFF
--- a/yaml/com/ibm/Dump/Create.interface.yaml
+++ b/yaml/com/ibm/Dump/Create.interface.yaml
@@ -61,3 +61,7 @@ enumerations:
             description: >
                 A dump collected from Self Boot Engine on the memory buffer when
                 it encounters critical failures or unresponsive.
+          - name: "SPPE"
+            description: >
+                A dump collected from Secure PPE(SPPE) on the processor when it
+                encounters critical failures or unresponsive.


### PR DESCRIPTION
SPPE is an additional new kind of SBE in the processor added for security purpose which limits outside interactions with the actual SBE. This commit adds the `SPPE` type to the com.ibm.Dump.Create interface. The structure and input to collect this dump is different from the processor SBE dump so making it a new dump type.

Change-Id: Ib94a0163c60e2c9c7f7d7b3b57efa4743a3ddce9