### PR TITLE
com:ibm: Add SecureExchange Interface

### DIFF
--- a/gen/com/ibm/Attestation/SecureExchange/SecureExchange/meson.build
+++ b/gen/com/ibm/Attestation/SecureExchange/SecureExchange/meson.build
@@ -1,0 +1,45 @@
+# Generated file; do not modify.
+
+sdbusplus_current_path = 'com/ibm/Attestation/SecureExchange/SecureExchange'
+
+generated_sources += custom_target(
+    'com/ibm/Attestation/SecureExchange/SecureExchange__cpp'.underscorify(),
+    input: [
+        '../../../../../../yaml/com/ibm/Attestation/SecureExchange/SecureExchange.errors.yaml',
+        '../../../../../../yaml/com/ibm/Attestation/SecureExchange/SecureExchange.interface.yaml',
+    ],
+    output: [
+        'error.cpp',
+        'error.hpp',
+        'common.hpp',
+        'server.hpp',
+        'server.cpp',
+        'aserver.hpp',
+        'client.hpp',
+    ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog,
+        '--command',
+        'cpp',
+        '--output',
+        meson.current_build_dir(),
+        '--tool',
+        sdbusplusplus_prog,
+        '--directory',
+        meson.current_source_dir() / '../../../../../../yaml',
+        'com/ibm/Attestation/SecureExchange/SecureExchange',
+    ],
+    install: should_generate_cpp,
+    install_dir: [
+        false,
+        get_option('includedir') / sdbusplus_current_path,
+        get_option('includedir') / sdbusplus_current_path,
+        get_option('includedir') / sdbusplus_current_path,
+        false,
+        get_option('includedir') / sdbusplus_current_path,
+        get_option('includedir') / sdbusplus_current_path,
+    ],
+    build_by_default: should_generate_cpp,
+)
+

--- a/gen/com/ibm/Attestation/SecureExchange/meson.build
+++ b/gen/com/ibm/Attestation/SecureExchange/meson.build
@@ -1,0 +1,30 @@
+# Generated file; do not modify.
+subdir('SecureExchange')
+
+sdbusplus_current_path = 'com/ibm/Attestation/SecureExchange'
+
+generated_markdown += custom_target(
+    'com/ibm/Attestation/SecureExchange/SecureExchange__markdown'.underscorify(),
+    input: [
+        '../../../../../yaml/com/ibm/Attestation/SecureExchange/SecureExchange.errors.yaml',
+        '../../../../../yaml/com/ibm/Attestation/SecureExchange/SecureExchange.interface.yaml',
+    ],
+    output: ['SecureExchange.md'],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog,
+        '--command',
+        'markdown',
+        '--output',
+        meson.current_build_dir(),
+        '--tool',
+        sdbusplusplus_prog,
+        '--directory',
+        meson.current_source_dir() / '../../../../../yaml',
+        'com/ibm/Attestation/SecureExchange/SecureExchange',
+    ],
+    install: should_generate_markdown,
+    install_dir: [inst_markdown_dir / sdbusplus_current_path],
+    build_by_default: should_generate_markdown,
+)
+

--- a/gen/com/ibm/Attestation/meson.build
+++ b/gen/com/ibm/Attestation/meson.build
@@ -1,0 +1,2 @@
+# Generated file; do not modify.
+subdir('SecureExchange')

--- a/gen/com/ibm/meson.build
+++ b/gen/com/ibm/meson.build
@@ -1,4 +1,5 @@
 # Generated file; do not modify.
+subdir('Attestation')
 subdir('Control')
 subdir('Dump')
 subdir('Hardware')

--- a/yaml/com/ibm/Attestation/SecureExchange/SecureExchange.errors.yaml
+++ b/yaml/com/ibm/Attestation/SecureExchange/SecureExchange.errors.yaml
@@ -1,0 +1,4 @@
+- name: AlreadyPaired
+  description: >
+      The Responder is already paired and the requested operation cannot be
+      performed again.

--- a/yaml/com/ibm/Attestation/SecureExchange/SecureExchange.interface.yaml
+++ b/yaml/com/ibm/Attestation/SecureExchange/SecureExchange.interface.yaml
@@ -1,0 +1,15 @@
+description: >
+    Interface to perform application-specific data exchange over an already
+    established SPDM secure session between requester and responder.
+
+methods:
+    - name: ExchangeAppData
+      description: >
+          Perform application data exchange over the active SPDM secure session.
+          The session must already be established and authenticated.
+
+      errors:
+          - self.Error.AlreadyPaired
+          - xyz.openbmc_project.Common.Error.NotAllowed
+          - xyz.openbmc_project.Common.Error.InternalFailure
+          - xyz.openbmc_project.Common.Error.Timeout


### PR DESCRIPTION
SecureExchange Interface will expose an API through which the pairing application can trigger the CA exchange over the secure channel.