### PR TITLE
Audit Log: Correct type for GetLatestEntries parameter

### DIFF
--- a/yaml/xyz/openbmc_project/Logging/AuditLog.interface.yaml
+++ b/yaml/xyz/openbmc_project/Logging/AuditLog.interface.yaml
@@ -23,7 +23,7 @@ methods:
           sorted newest to oldest.
       parameters:
           - name: maxCount
-            type: uint32
+            type: size
             description:
                 Defines the maximum number of entries to return. Minimum value
                 is 0.


### PR DESCRIPTION
The GetLatestEntries method for the audit log service accepts a single parameter. It was defined as a uint32. The bmcweb caller is passing a size_t variable. For AST2600 builds size_t was a uint32. For AST2700 size_t is now a uint64. This results in a failure due to type mismatch on the D-Bus call from bmcweb.

```
method call time=1773087858.386015 sender=:1.75 -> destination=xyz.openbmc_project.Logging.AuditLog serial=4347 path=/xyz/openbmc_project/logging/auditlog; interface=xyz.openbmc_project.Logging.AuditLog; member=GetLatestEntries
   uint64 1000
```

The phosphor-dbus-interfaces documentation suggests the use of size for counting variables unless there is an underlying reason to use something else.[1] There is no underlying reason to use a uint32 so the interface is being changed to use size.

[1] https://github.com/ibm-openbmc/phosphor-dbus-interfaces/blob/1210/requirements.md#prefer-size-and-uint64int64-over-explicit-sizes

Tested:
 - Using updated phosphor-auditlog confirmed bmcweb is now able to successfully retrieve the audit log entries.