### PR TITLE
Update VPD Manager interface YAML

### DIFF
--- a/yaml/com/ibm/VPD/Manager.interface.yaml
+++ b/yaml/com/ibm/VPD/Manager.interface.yaml
@@ -75,6 +75,28 @@ methods:
       errors:
           - xyz.openbmc_project.Common.Error.InvalidArgument
 
+    - name: ReadKeyword
+      description: >
+          Method to read a single keyword's value based on the input parameters.
+      parameters:
+          - name: path
+            type: string
+            description: >
+                EEPROM path of the FRU.
+          - name: paramsToReadData
+            type: variant[struct[string,string],string]
+            description: >
+                Parameters in required format to read the keyword's value.
+      returns:
+          - name: keywordValue
+            type: variant[array[byte]]
+            description: >
+                On success, returns the keyword's value. On failure, throws an
+                exception.
+      errors:
+          - xyz.openbmc_project.Common.Error.InvalidArgument
+          - xyz.openbmc_project.Common.Device.Error.ReadFailure
+
     - name: GetFRUsByUnexpandedLocationCode
       description: >
           A method to get list of FRU D-BUS object paths for a given unexpanded

--- a/yaml/com/ibm/VPD/Manager.interface.yaml
+++ b/yaml/com/ibm/VPD/Manager.interface.yaml
@@ -27,6 +27,31 @@ methods:
           - com.ibm.VPD.Error.RecordNotFound
           - com.ibm.VPD.Error.KeywordNotFound
 
+    - name: UpdateKeyword
+      description: >
+          Method to update a single keyword's value based on the input
+          parameters.
+      parameters:
+          - name: path
+            type: string
+            description: >
+                Path where the data resides (D-Bus inventory path/EEPROM path
+                etc).
+          - name: paramsToWriteData
+            type:
+                variant[struct[string,string,array[byte]],
+                struct[string,array[byte]]]
+            description: >
+                Parameters in required format to write the keyword's value.
+      returns:
+          - name: bytesUpdated
+            type: ssize
+            description: >
+                On success, returns the number of bytes updated. On failure,
+                returns -1.
+      errors:
+          - xyz.openbmc_project.Common.Error.InvalidArgument
+
     - name: GetFRUsByUnexpandedLocationCode
       description: >
           A method to get list of FRU D-BUS object paths for a given unexpanded

--- a/yaml/com/ibm/VPD/Manager.interface.yaml
+++ b/yaml/com/ibm/VPD/Manager.interface.yaml
@@ -137,6 +137,28 @@ methods:
       errors:
           - xyz.openbmc_project.Common.Error.InvalidArgument
 
+    - name: GetHardwarePath
+      description: >
+          Method to get the hardware path(s) for the corresponding inventory
+          path.
+      parameters:
+          - name: inventoryPath
+            type: object_path
+            description: >
+                Dbus inventory path of the FRU.
+      returns:
+          - name: hardwarePaths
+            type: array[string]
+            description: >
+                An array containing hardware paths corresponding to given D-Bus
+                object path. The first entry represents the primary hardware
+                path. All other entries(if any) represents the redundant
+                hardware paths. Note: The inventory path must be present in the
+                system configuration JSON used by vpd-manager.
+      errors:
+          - xyz.openbmc_project.Common.Error.InvalidArgument
+          - com.ibm.VPD.Error.PathNotFound
+
     - name: DeleteAllFRUVPD
       description: >
           Method to clear all FRU VPD other than the system VPD from PIM

--- a/yaml/com/ibm/VPD/Manager.interface.yaml
+++ b/yaml/com/ibm/VPD/Manager.interface.yaml
@@ -181,3 +181,40 @@ methods:
                 True if both EEPROMs contain identical VPD, false otherwise.
       errors:
           - xyz.openbmc_project.Common.Error.InvalidArgument
+
+    - name: CollectAllFRUVPD
+      description: >
+          Method to collect VPD of all FRUs in the system configuration JSON.
+      returns:
+          - name: result
+            type: boolean
+            description: >
+                True if collection was successfully initiated, false otherwise.
+                Note: This return value just indicates if the collection has
+                been successfully initiated. It doesn't indicate VPD collection
+                status of the system.
+
+properties:
+    - name: CollectionStatus
+      type: enum[self.Status]
+      default: NotStarted
+      description: >
+          VPD collection status of the system.
+
+enumerations:
+    - name: Status
+      description: >
+          VPD collection status of the system.
+      values:
+          - name: NotStarted
+            description: >
+                VPD collection has not started.
+          - name: InProgress
+            description: >
+                VPD collection is in progress.
+          - name: Completed
+            description: >
+                VPD collection is completed.
+          - name: Failure
+            description: >
+                VPD collection has failed.

--- a/yaml/com/ibm/VPD/Manager.interface.yaml
+++ b/yaml/com/ibm/VPD/Manager.interface.yaml
@@ -52,6 +52,29 @@ methods:
       errors:
           - xyz.openbmc_project.Common.Error.InvalidArgument
 
+    - name: WriteKeywordOnHardware
+      description: >
+          Method to update a single keyword's value on the hardware.
+      parameters:
+          - name: path
+            type: string
+            description: >
+                EEPROM path of the FRU.
+          - name: paramsToWriteData
+            type:
+                variant[struct[string,string,array[byte]],
+                struct[string,array[byte]]]
+            description: >
+                Parameters in required format to write the keyword's value.
+      returns:
+          - name: bytesUpdated
+            type: ssize
+            description: >
+                On success, returns the number of bytes updated. On failure,
+                returns -1.
+      errors:
+          - xyz.openbmc_project.Common.Error.InvalidArgument
+
     - name: GetFRUsByUnexpandedLocationCode
       description: >
           A method to get list of FRU D-BUS object paths for a given unexpanded


### PR DESCRIPTION
This commit updates the Manager.interface.yaml file which describes the D-Bus methods exposed by vpd-manager service. vpd-manager exposes some additional D-Bus methods  which are not reflected in the YAML file. These methods are:
1. GetHardwarePath
2. CollectAllFRUVPD

As the YAML file acts as an agreement between vpd-manager and other services, it should accurately represent all D-Bus methods exposed by vpd-manager.

Cherry-pick of following upstream commits:
1. https://github.com/openbmc/phosphor-dbus-interfaces/commit/f3280013a1b2451689035e32a30654e83f40fb7f
2. https://github.com/openbmc/phosphor-dbus-interfaces/commit/8e083998e80ccccf01481279f772717b4c4f1a20

Also includes following changes:

1. IBM: vpd-manager YAML: add CollectAllFRUVPD API
2. IBM: add UpdateKeyword API YAML descriptor
3. IBM : add WriteKeywordOnHardware D-Bus API YAML