### PR TITLE
Changed Keyword "Provisioning" to "BmcPairing" for peer BMC.

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-10-17T10:22:59Z",
+  "generated_at": "2025-11-04T05:14:57Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -100,7 +100,7 @@
         "hashed_secret": "3b4d89f26594b275f7572bb14fed31ac4c9b5981",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 33,
+        "line_number": 34,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -108,7 +108,7 @@
         "hashed_secret": "32cae99c56c08352b024c5143a153260ff0732de",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 57,
+        "line_number": 58,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -116,7 +116,15 @@
         "hashed_secret": "287aa7ca33e2caf581397144b4d99ce2bac77a31",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 73,
+        "line_number": 74,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "36f1271c7f90ee47258dc98bab74b4ae006fb7e9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 82,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }

--- a/gen/com/ibm/Attestation/SecureExchange/SecureExchange/meson.build
+++ b/gen/com/ibm/Attestation/SecureExchange/SecureExchange/meson.build
@@ -1,0 +1,45 @@
+# Generated file; do not modify.
+
+sdbusplus_current_path = 'com/ibm/Attestation/SecureExchange/SecureExchange'
+
+generated_sources += custom_target(
+    'com/ibm/Attestation/SecureExchange/SecureExchange__cpp'.underscorify(),
+    input: [
+        '../../../../../../yaml/com/ibm/Attestation/SecureExchange/SecureExchange.errors.yaml',
+        '../../../../../../yaml/com/ibm/Attestation/SecureExchange/SecureExchange.interface.yaml',
+    ],
+    output: [
+        'error.cpp',
+        'error.hpp',
+        'common.hpp',
+        'server.hpp',
+        'server.cpp',
+        'aserver.hpp',
+        'client.hpp',
+    ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog,
+        '--command',
+        'cpp',
+        '--output',
+        meson.current_build_dir(),
+        '--tool',
+        sdbusplusplus_prog,
+        '--directory',
+        meson.current_source_dir() / '../../../../../../yaml',
+        'com/ibm/Attestation/SecureExchange/SecureExchange',
+    ],
+    install: should_generate_cpp,
+    install_dir: [
+        false,
+        get_option('includedir') / sdbusplus_current_path,
+        get_option('includedir') / sdbusplus_current_path,
+        get_option('includedir') / sdbusplus_current_path,
+        false,
+        get_option('includedir') / sdbusplus_current_path,
+        get_option('includedir') / sdbusplus_current_path,
+    ],
+    build_by_default: should_generate_cpp,
+)
+

--- a/gen/com/ibm/Attestation/SecureExchange/meson.build
+++ b/gen/com/ibm/Attestation/SecureExchange/meson.build
@@ -1,0 +1,30 @@
+# Generated file; do not modify.
+subdir('SecureExchange')
+
+sdbusplus_current_path = 'com/ibm/Attestation/SecureExchange'
+
+generated_markdown += custom_target(
+    'com/ibm/Attestation/SecureExchange/SecureExchange__markdown'.underscorify(),
+    input: [
+        '../../../../../yaml/com/ibm/Attestation/SecureExchange/SecureExchange.errors.yaml',
+        '../../../../../yaml/com/ibm/Attestation/SecureExchange/SecureExchange.interface.yaml',
+    ],
+    output: ['SecureExchange.md'],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog,
+        '--command',
+        'markdown',
+        '--output',
+        meson.current_build_dir(),
+        '--tool',
+        sdbusplusplus_prog,
+        '--directory',
+        meson.current_source_dir() / '../../../../../yaml',
+        'com/ibm/Attestation/SecureExchange/SecureExchange',
+    ],
+    install: should_generate_markdown,
+    install_dir: [inst_markdown_dir / sdbusplus_current_path],
+    build_by_default: should_generate_markdown,
+)
+

--- a/gen/com/ibm/Attestation/meson.build
+++ b/gen/com/ibm/Attestation/meson.build
@@ -1,0 +1,2 @@
+# Generated file; do not modify.
+subdir('SecureExchange')

--- a/gen/com/ibm/meson.build
+++ b/gen/com/ibm/meson.build
@@ -1,4 +1,5 @@
 # Generated file; do not modify.
+subdir('Attestation')
 subdir('Control')
 subdir('Dump')
 subdir('Hardware')

--- a/gen/xyz/openbmc_project/BIOSConfig/SecureBoot/meson.build
+++ b/gen/xyz/openbmc_project/BIOSConfig/SecureBoot/meson.build
@@ -1,0 +1,40 @@
+# Generated file; do not modify.
+
+sdbusplus_current_path = 'xyz/openbmc_project/BIOSConfig/SecureBoot'
+
+generated_sources += custom_target(
+    'xyz/openbmc_project/BIOSConfig/SecureBoot__cpp'.underscorify(),
+    input: [
+        '../../../../../yaml/xyz/openbmc_project/BIOSConfig/SecureBoot.interface.yaml',
+    ],
+    output: [
+        'common.hpp',
+        'server.hpp',
+        'server.cpp',
+        'aserver.hpp',
+        'client.hpp',
+    ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog,
+        '--command',
+        'cpp',
+        '--output',
+        meson.current_build_dir(),
+        '--tool',
+        sdbusplusplus_prog,
+        '--directory',
+        meson.current_source_dir() / '../../../../../yaml',
+        'xyz/openbmc_project/BIOSConfig/SecureBoot',
+    ],
+    install: should_generate_cpp,
+    install_dir: [
+        get_option('includedir') / sdbusplus_current_path,
+        get_option('includedir') / sdbusplus_current_path,
+        false,
+        get_option('includedir') / sdbusplus_current_path,
+        get_option('includedir') / sdbusplus_current_path,
+    ],
+    build_by_default: should_generate_cpp,
+)
+

--- a/gen/xyz/openbmc_project/BIOSConfig/meson.build
+++ b/gen/xyz/openbmc_project/BIOSConfig/meson.build
@@ -2,6 +2,7 @@
 subdir('Common')
 subdir('Manager')
 subdir('Password')
+subdir('SecureBoot')
 
 sdbusplus_current_path = 'xyz/openbmc_project/BIOSConfig'
 
@@ -71,6 +72,30 @@ generated_markdown += custom_target(
         '--directory',
         meson.current_source_dir() / '../../../../yaml',
         'xyz/openbmc_project/BIOSConfig/Password',
+    ],
+    install: should_generate_markdown,
+    install_dir: [inst_markdown_dir / sdbusplus_current_path],
+    build_by_default: should_generate_markdown,
+)
+
+generated_markdown += custom_target(
+    'xyz/openbmc_project/BIOSConfig/SecureBoot__markdown'.underscorify(),
+    input: [
+        '../../../../yaml/xyz/openbmc_project/BIOSConfig/SecureBoot.interface.yaml',
+    ],
+    output: ['SecureBoot.md'],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog,
+        '--command',
+        'markdown',
+        '--output',
+        meson.current_build_dir(),
+        '--tool',
+        sdbusplusplus_prog,
+        '--directory',
+        meson.current_source_dir() / '../../../../yaml',
+        'xyz/openbmc_project/BIOSConfig/SecureBoot',
     ],
     install: should_generate_markdown,
     install_dir: [inst_markdown_dir / sdbusplus_current_path],

--- a/yaml/com/ibm/Attestation/SecureExchange/SecureExchange.errors.yaml
+++ b/yaml/com/ibm/Attestation/SecureExchange/SecureExchange.errors.yaml
@@ -1,0 +1,4 @@
+- name: AlreadyPaired
+  description: >
+      The Responder is already paired and the requested operation cannot be
+      performed again.

--- a/yaml/com/ibm/Attestation/SecureExchange/SecureExchange.interface.yaml
+++ b/yaml/com/ibm/Attestation/SecureExchange/SecureExchange.interface.yaml
@@ -1,0 +1,15 @@
+description: >
+    Interface to perform application-specific data exchange over an already
+    established SPDM secure session between requester and responder.
+
+methods:
+    - name: ExchangeAppData
+      description: >
+          Perform application data exchange over the active SPDM secure session.
+          The session must already be established and authenticated.
+
+      errors:
+          - self.Error.AlreadyPaired
+          - xyz.openbmc_project.Common.Error.NotAllowed
+          - xyz.openbmc_project.Common.Error.InternalFailure
+          - xyz.openbmc_project.Common.Error.Timeout

--- a/yaml/xyz/openbmc_project/BIOSConfig/SecureBoot.interface.yaml
+++ b/yaml/xyz/openbmc_project/BIOSConfig/SecureBoot.interface.yaml
@@ -1,0 +1,59 @@
+description: >
+    UEFI Secure Boot information and represents properties for managing the UEFI
+    Secure Boot functionality of a system.
+
+properties:
+    - name: CurrentBoot
+      type: enum[self.CurrentBootType]
+      description: >
+          The UEFI Secure Boot state during the current boot cycle.
+      default: Unknown
+
+    - name: PendingEnable
+      type: boolean
+      description: >
+          An indication of whether the UEFI Secure Boot takes effect on next
+          boot.
+
+    - name: Mode
+      type: enum[self.ModeType]
+      description: >
+          The current UEFI Secure Boot Mode.
+      default: Unknown
+
+enumerations:
+    - name: CurrentBootType
+      description: >
+          Secure Boot Current Boot Type.
+      values:
+          - name: Unknown
+            description: >
+                UEFI Secure Boot is currently unknown.
+          - name: Enabled
+            description: >
+                UEFI Secure Boot is currently enabled.
+          - name: Disabled
+            description: >
+                UEFI Secure Boot is currently disabled.
+
+    - name: ModeType
+      description: >
+          Secure Boot Mode Type. UEFI Secure Boot Modes are defined in UEFI
+          Specification -
+          https://uefi.org/specs/UEFI/2.10/32_Secure_Boot_and_Driver_Signing.html#secure-boot-modes
+      values:
+          - name: Unknown
+            description: >
+                UEFI Secure Boot is currently unknown.
+          - name: Setup
+            description: >
+                UEFI Secure Boot is currently in Setup Mode.
+          - name: User
+            description: >
+                UEFI Secure Boot is currently in User Mode.
+          - name: Audit
+            description: >
+                UEFI Secure Boot is currently in Audit Mode.
+          - name: Deployed
+            description: >
+                UEFI Secure Boot is currently in Deployed Mode.

--- a/yaml/xyz/openbmc_project/BmcPairing/BmcPairing.interface.yaml
+++ b/yaml/xyz/openbmc_project/BmcPairing/BmcPairing.interface.yaml
@@ -1,0 +1,82 @@
+description: >
+    Interface representing the pairing state and peer connectivity status
+    of the BMC. It provides properties to indicate whether the BMC has been
+    pairned and the current connection state with the peer BMC, along with a
+    method to initiate peer pairing and a signal to report its result.
+
+properties:
+    - name: Paired
+      type: boolean
+      flags:
+          - readonly
+      description: >
+          True means the BMC is in a paired state.
+    - name: PeerConnected
+      type: enum[self.PeerConnectionStatus]
+      flags:
+          - readonly
+      default: NotDetermined
+      description: >
+          Represents the connection status with the peer BMC.
+
+methods:
+    - name: PairPeer
+      description: >
+          Starts the pairing process on the peerBmc .
+      parameters:
+          - name: bmcId
+            type: string
+            description: >
+                Identifier of the peer BMC to be paired.
+      returns:
+          - name: Path
+            type: object_path
+            description: >
+                The object path of the object that implements
+                xyz.openbmc_project.Common.Progress to track the progress of
+                paring process.
+      errors:
+          - xyz.openbmc_project.Common.Error.NotAllowed
+
+enumerations:
+    - name: PeerConnectionStatus
+      description: >
+          Enumerates the possible states of peer BMC connectivity.
+      values:
+          - name: NotDetermined
+            description: >
+                The peer connection status has not been determined yet.
+          - name: InProgress
+            description: >
+                The system is currently attempting to determine the connection
+                status with the peer BMC.
+          - name: Connected
+            description: >
+                The peer BMC is detected and reachable.
+          - name: NotConnected
+            description: >
+                Peer BMC connection failed.
+    - name: PairingStatus
+      description: >
+          Enumerates the possible states of pairing status of peer BMC.
+      values:
+          - name: DeviceAuthInProgress
+            description: >
+                Device authentication with the peer BMC is in progress.
+          - name: MeasurementVerificationInProgress
+            description: >
+                Measurement verification of the peer BMC is in progress.
+          - name: ExchangeCertificateInProgress
+            description: >
+                Certificate exchange with the peer BMC is in progress.
+          - name: PairingSuccess
+            description: >
+                Pairing configuration succeded.
+          - name: PairingFailed
+            description: >
+                Pairing configuration failed.
+
+paths:
+    - instance: /xyz/openbmc_project/Pairing
+      description: >
+          Expected path of the Pairing interface instance.

--- a/yaml/xyz/openbmc_project/Network/LLDP/TLVs.interface.yaml
+++ b/yaml/xyz/openbmc_project/Network/LLDP/TLVs.interface.yaml
@@ -63,12 +63,24 @@ properties:
           IPv4 management address of the device. This is the IPv4 address used
           for managing the device.
 
+    - name: ManagementAddressIPv4Array
+      type: array[string]
+      description: >
+          Contains additional IPv4 management addresses transmitted or received
+          on this link.
+
     - name: ManagementAddressIPv6
       type: string
       default: ""
       description: >
           IPv6 management address of the device. This is the IPv6 address used
           for managing the device.
+
+    - name: ManagementAddressIPv6Array
+      type: array[string]
+      description: >
+          Contains additional IPv6 management addresses transmitted or received
+          on this link.
 
     - name: ManagementAddressMAC
       type: string
@@ -83,6 +95,13 @@ properties:
       description: >
           VLAN ID used for management traffic. This is the VLAN ID used for
           managing the device.
+
+    - name: ExchangeType
+      type: enum[self.LLDPExchangeType]
+      default: Unknown
+      description: >
+          Indicates whether this LLDP TLVs object represents transmitted or
+          received LLDP information.
 
 enumerations:
     - name: IEEE802IdSubtype
@@ -112,3 +131,11 @@ enumerations:
           - name: Station
           - name: Telephone
           - name: WLANAccessPoint
+
+    - name: LLDPExchangeType
+      description: >
+          The direction of LLDP TLVs.
+      values:
+          - name: Transmit
+          - name: Receive
+          - name: Unknown

--- a/yaml/xyz/openbmc_project/Provisioning/Provisioning.interface.yaml
+++ b/yaml/xyz/openbmc_project/Provisioning/Provisioning.interface.yaml
@@ -28,6 +28,8 @@ methods:
             type: string
             description: >
                 Identifier of the peer BMC to be provisioned.
+      errors:
+          - xyz.openbmc_project.Common.Error.NotAllowed
 
 signals:
     - name: PeerProvisioned


### PR DESCRIPTION
Changed the keyword from "Provisioning" to "BmcPairing" for peer BMC.

Instead of modifying the existing YAML file, a new YAML file was created to replace the current one (yaml/xyz/openbmc_project/Provisioning/Provisioning.interface.yaml), ensuring that the existing functionality is not broken.
Will remove the old yaml file and keep the new one in future.
