### PR TITLE
Pull Attestation & SPDMTCPResponder changes from upstream

### DIFF
--- a/gen/xyz/openbmc_project/Configuration/SpdmTcpResponder/meson.build
+++ b/gen/xyz/openbmc_project/Configuration/SpdmTcpResponder/meson.build
@@ -1,0 +1,40 @@
+# Generated file; do not modify.
+
+sdbusplus_current_path = 'xyz/openbmc_project/Configuration/SpdmTcpResponder'
+
+generated_sources += custom_target(
+    'xyz/openbmc_project/Configuration/SpdmTcpResponder__cpp'.underscorify(),
+    input: [
+        '../../../../../yaml/xyz/openbmc_project/Configuration/SpdmTcpResponder.interface.yaml',
+    ],
+    output: [
+        'common.hpp',
+        'server.hpp',
+        'server.cpp',
+        'aserver.hpp',
+        'client.hpp',
+    ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog,
+        '--command',
+        'cpp',
+        '--output',
+        meson.current_build_dir(),
+        '--tool',
+        sdbusplusplus_prog,
+        '--directory',
+        meson.current_source_dir() / '../../../../../yaml',
+        'xyz/openbmc_project/Configuration/SpdmTcpResponder',
+    ],
+    install: should_generate_cpp,
+    install_dir: [
+        get_option('includedir') / sdbusplus_current_path,
+        get_option('includedir') / sdbusplus_current_path,
+        false,
+        get_option('includedir') / sdbusplus_current_path,
+        get_option('includedir') / sdbusplus_current_path,
+    ],
+    build_by_default: should_generate_cpp,
+)
+

--- a/gen/xyz/openbmc_project/Configuration/meson.build
+++ b/gen/xyz/openbmc_project/Configuration/meson.build
@@ -1,6 +1,7 @@
 # Generated file; do not modify.
 subdir('GPIODeviceDetect')
 subdir('GPIOLeakDetector')
+subdir('SpdmTcpResponder')
 
 sdbusplus_current_path = 'xyz/openbmc_project/Configuration'
 
@@ -46,6 +47,30 @@ generated_markdown += custom_target(
         '--directory',
         meson.current_source_dir() / '../../../../yaml',
         'xyz/openbmc_project/Configuration/GPIOLeakDetector',
+    ],
+    install: should_generate_markdown,
+    install_dir: [inst_markdown_dir / sdbusplus_current_path],
+    build_by_default: should_generate_markdown,
+)
+
+generated_markdown += custom_target(
+    'xyz/openbmc_project/Configuration/SpdmTcpResponder__markdown'.underscorify(),
+    input: [
+        '../../../../yaml/xyz/openbmc_project/Configuration/SpdmTcpResponder.interface.yaml',
+    ],
+    output: ['SpdmTcpResponder.md'],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog,
+        '--command',
+        'markdown',
+        '--output',
+        meson.current_build_dir(),
+        '--tool',
+        sdbusplusplus_prog,
+        '--directory',
+        meson.current_source_dir() / '../../../../yaml',
+        'xyz/openbmc_project/Configuration/SpdmTcpResponder',
     ],
     install: should_generate_markdown,
     install_dir: [inst_markdown_dir / sdbusplus_current_path],

--- a/gen/xyz/openbmc_project/Control/Security/SPDM/Policy/meson.build
+++ b/gen/xyz/openbmc_project/Control/Security/SPDM/Policy/meson.build
@@ -1,0 +1,40 @@
+# Generated file; do not modify.
+
+sdbusplus_current_path = 'xyz/openbmc_project/Control/Security/SPDM/Policy'
+
+generated_sources += custom_target(
+    'xyz/openbmc_project/Control/Security/SPDM/Policy__cpp'.underscorify(),
+    input: [
+        '../../../../../../../yaml/xyz/openbmc_project/Control/Security/SPDM/Policy.interface.yaml',
+    ],
+    output: [
+        'common.hpp',
+        'server.hpp',
+        'server.cpp',
+        'aserver.hpp',
+        'client.hpp',
+    ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog,
+        '--command',
+        'cpp',
+        '--output',
+        meson.current_build_dir(),
+        '--tool',
+        sdbusplusplus_prog,
+        '--directory',
+        meson.current_source_dir() / '../../../../../../../yaml',
+        'xyz/openbmc_project/Control/Security/SPDM/Policy',
+    ],
+    install: should_generate_cpp,
+    install_dir: [
+        get_option('includedir') / sdbusplus_current_path,
+        get_option('includedir') / sdbusplus_current_path,
+        false,
+        get_option('includedir') / sdbusplus_current_path,
+        get_option('includedir') / sdbusplus_current_path,
+    ],
+    build_by_default: should_generate_cpp,
+)
+

--- a/gen/xyz/openbmc_project/Control/Security/SPDM/meson.build
+++ b/gen/xyz/openbmc_project/Control/Security/SPDM/meson.build
@@ -1,0 +1,29 @@
+# Generated file; do not modify.
+subdir('Policy')
+
+sdbusplus_current_path = 'xyz/openbmc_project/Control/Security/SPDM'
+
+generated_markdown += custom_target(
+    'xyz/openbmc_project/Control/Security/SPDM/Policy__markdown'.underscorify(),
+    input: [
+        '../../../../../../yaml/xyz/openbmc_project/Control/Security/SPDM/Policy.interface.yaml',
+    ],
+    output: ['Policy.md'],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog,
+        '--command',
+        'markdown',
+        '--output',
+        meson.current_build_dir(),
+        '--tool',
+        sdbusplusplus_prog,
+        '--directory',
+        meson.current_source_dir() / '../../../../../../yaml',
+        'xyz/openbmc_project/Control/Security/SPDM/Policy',
+    ],
+    install: should_generate_markdown,
+    install_dir: [inst_markdown_dir / sdbusplus_current_path],
+    build_by_default: should_generate_markdown,
+)
+

--- a/gen/xyz/openbmc_project/Control/Security/meson.build
+++ b/gen/xyz/openbmc_project/Control/Security/meson.build
@@ -1,5 +1,6 @@
 # Generated file; do not modify.
 subdir('RestrictionMode')
+subdir('SPDM')
 subdir('SpecialMode')
 
 sdbusplus_current_path = 'xyz/openbmc_project/Control/Security'

--- a/yaml/xyz/openbmc_project/Attestation/ComponentIntegrity.interface.yaml
+++ b/yaml/xyz/openbmc_project/Attestation/ComponentIntegrity.interface.yaml
@@ -73,3 +73,6 @@ enumerations:
           - name: Unknown
             description: >
                 Security technology not known yet.
+
+paths:
+    - namespace: /xyz/openbmc_project/component_integrity

--- a/yaml/xyz/openbmc_project/Attestation/IdentityAuthentication.interface.yaml
+++ b/yaml/xyz/openbmc_project/Attestation/IdentityAuthentication.interface.yaml
@@ -42,3 +42,6 @@ enumerations:
           - name: Unknown
             description: >
                 Status not known yet.
+
+paths:
+    - namespace: /xyz/openbmc_project/component_integrity

--- a/yaml/xyz/openbmc_project/Attestation/MeasurementSet.interface.yaml
+++ b/yaml/xyz/openbmc_project/Attestation/MeasurementSet.interface.yaml
@@ -60,3 +60,6 @@ methods:
       errors:
           - xyz.openbmc_project.Common.Error.InvalidArgument
           - xyz.openbmc_project.Common.Error.InternalFailure
+
+paths:
+    - namespace: /xyz/openbmc_project/component_integrity

--- a/yaml/xyz/openbmc_project/Configuration/SpdmTcpResponder.interface.yaml
+++ b/yaml/xyz/openbmc_project/Configuration/SpdmTcpResponder.interface.yaml
@@ -1,0 +1,18 @@
+description: >
+    Configuration interface for SPDM TCP Responder. This interface is used by
+    Entity Manager to configure SPDM devices that communicate over TCP.
+
+properties:
+    - name: Hostname
+      type: string
+      description: >
+          The hostname or IP address of the SPDM TCP responder.
+      flags:
+          - readonly
+
+    - name: Port
+      type: uint64
+      description: >
+          The TCP port number for the SPDM responder.
+      flags:
+          - readonly

--- a/yaml/xyz/openbmc_project/Control/Security/SPDM/Policy.interface.yaml
+++ b/yaml/xyz/openbmc_project/Control/Security/SPDM/Policy.interface.yaml
@@ -1,0 +1,70 @@
+description: >
+    Used to configure security policies related to the SPDM protocol and its
+    supported versions, features, and algorithms.
+
+properties:
+    - name: Enabled
+      type: boolean
+      default: false
+      description: >
+          Indicates whether SPDM communication is enabled.
+
+    - name: SecureSessionEnabled
+      type: boolean
+      default: false
+      description: >
+          Indicates whether SPDM secure sessions with devices are enabled.
+
+    - name: VerifyCertificate
+      type: boolean
+      default: false
+      description: >
+          Indicates whether certificate verification of SPDM endpoints is
+          enabled.
+
+    - name: AllowExtendedAlgorithms
+      type: boolean
+      default: false
+      description: >
+          Allows the use of extended SPDM algorithms as defined in DSP0274.
+
+    - name: AllowedVersions
+      type: array[variant[enum[self.SpecialSetValues], string]]
+      description: >
+          Allowed SPDM protocol versions. Acceptable special values: ALL, NONE,
+          or explicit SPDM version numbers in the required "major.minor" format
+          (e.g., "1.2", "1.1").
+
+    - name: AllowedAlgorithmsAEAD
+      type: array[variant[enum[self.SpecialSetValues], string]]
+      description: >
+          Allowed AEAD algorithms for SPDM operations. Valid values are the AEAD
+          algorithm names defined in the 'AlgSupported' field of the AEAD
+          structure in DSP0274, "ALL" and "NONE".
+
+    - name: AllowedAlgorithmsBaseHash
+      type: array[variant[enum[self.SpecialSetValues], string]]
+      description: >
+          Allowed base hash algorithms for SPDM operations. Valid values are the
+          hash algorithm names defined in the 'BaseHashAlgo' field of the
+          NEGOTIATE_ALGORITHMS request in DSP0274, "ALL" and "NONE".
+
+    - name: AllowedAlgorithmsBaseAsym
+      type: array[variant[enum[self.SpecialSetValues], string]]
+      description: >
+          Allowed asymmetric signature algorithms for SPDM operations. Valid
+          values are the asymmetric signature algorithm names defined in the
+          'BaseAsymAlgo' field of the NEGOTIATE_ALGORITHMS request in DSP0274,
+          "ALL" and "NONE".
+
+enumerations:
+    - name: SpecialSetValues
+      description: >
+          Defines special set-selection values for SPDM versions or algorithms.
+      values:
+          - name: ALL
+            description: >
+                All supported SPDM versions or algorithms are permitted.
+          - name: NONE
+            description: >
+                No SPDM versions or algorithms are permitted.


### PR DESCRIPTION
This PR pulls in the below merged commits from upstream :

https://gerrit.openbmc.org/c/openbmc/phosphor-dbus-interfaces/+/88043
https://gerrit.openbmc.org/c/openbmc/phosphor-dbus-interfaces/+/82766
https://gerrit.openbmc.org/c/openbmc/phosphor-dbus-interfaces/+/85393