### PR TITLE
Add method to set BMC redundancy inputs

### DIFF
--- a/yaml/xyz/openbmc_project/Control/Failover.interface.yaml
+++ b/yaml/xyz/openbmc_project/Control/Failover.interface.yaml
@@ -14,7 +14,7 @@ methods:
             description: >
                 Identifies who's requesting the failover
           - name: Options
-            type: dict[string, variant[boolean]]
+            type: dict[string, variant[boolean, string]]
             description: >
                 Additional options. The key is the string version of the Options
                 enum, in the form of
@@ -57,3 +57,9 @@ enumerations:
                 A boolean option to force the failover when it would normally
                 not be available.  The checks it bypasses are implementation
                 dependent.
+          - name: UseRedundancyInput
+            description: >
+                When redundancy is re-calculated after the failover, use the
+                provided redundancy input. This will cause redundancy to be
+                disabled for that reason. The map value is the string version of
+                the RedundancyInput enum.

--- a/yaml/xyz/openbmc_project/State/BMC/Redundancy.interface.yaml
+++ b/yaml/xyz/openbmc_project/State/BMC/Redundancy.interface.yaml
@@ -1,6 +1,26 @@
 description: >
     This interface holds redundant BMC related information.
 
+methods:
+    - name: SetRedundancyInput
+      description: >
+          Passes an external redundancy input to the application, which is an
+          input used to calculate redundancy that the app can't figure out for
+          itself. It can be cleared by calling the method again with a value of
+          'false', though the redundant BMC application may also know when to
+          clear it.
+      parameters:
+          - name: input
+            type: enum[self.RedundancyInput]
+            description: >
+                The input type to set.
+          - name: value
+            type: boolean
+            description: >
+                The value to set.
+      errors:
+          - xyz.openbmc_project.Common.Error.NotAllowed
+
 properties:
     - name: Role
       type: enum[self.Role]
@@ -183,6 +203,23 @@ enumerations:
                 The system is not in the proper state, e.g. not off or at
                 runtime.
 
+    - name: RedundancyInput
+      description: >
+          An input used in the redundancy determination code passed in from an
+          external application.
+      values:
+          - name: PassiveBMCHostProcessorProblem
+            description: >
+                There is a hardware problem related to the passive BMC's
+                attached host processor preventing that BMC from becoming
+                active, so redundancy can't be enabled. An example is its
+                connected host processor is deconfigured.
+          - name: PassiveBMCHardwareProblem
+            description: >
+                There is a hardware problem with the passive BMC preventing it
+                from becoming active, so redundancy can't be enabled. An example
+                is it can't talk to its host processor. Replacing the BMC should
+                fix the issue.
 signals:
     - name: Heartbeat
       description: >


### PR DESCRIPTION
Add a setRedundancyInput method that can be used to set an external redundancy input so that another application an in effect disable redundancy.

Also add a new failover option so that after a failover is done one of these redundancy inputs will be set to disable redundancy afterwards.