### PR TITLE
Add error for NTP server property

### DIFF
--- a/yaml/xyz/openbmc_project/Network/EthernetInterface.interface.yaml
+++ b/yaml/xyz/openbmc_project/Network/EthernetInterface.interface.yaml
@@ -72,6 +72,8 @@ properties:
           This property describes statically defined NTPServers on the
           interface. This property supports read/write operation. Configure the
           NTP servers on the system during write operation.
+      errors:
+          - xyz.openbmc_project.Common.Error.InvalidArgument
     - name: LinkLocalAutoConf
       type: enum[self.LinkLocalConf]
       description: >


### PR DESCRIPTION
upstream: https://gerrit.openbmc.org/c/openbmc/phosphor-dbus-interfaces/+/82693
It is observed that on passing invalid arguments to configure NTP servers phosphor-netword is crashing because it is not throwing the invalid argument exception

To address the issue adding error invalid argument as it is not present currently. The MRs created for returning invalid argument are below

https://gerrit.openbmc.org/c/openbmc/phosphor-networkd/+/82694 and https://gerrit.openbmc.org/c/openbmc/bmcweb/+/82696

Change-Id: Iebd09b482d0938c614d87e9cbd8fa1b765e0309a