### PR TITLE
1210- Add support for ReadyToRemove interface

### DIFF
--- a/gen/xyz/openbmc_project/State/ReadyToRemove/meson.build
+++ b/gen/xyz/openbmc_project/State/ReadyToRemove/meson.build
@@ -1,0 +1,40 @@
+# Generated file; do not modify.
+
+sdbusplus_current_path = 'xyz/openbmc_project/State/ReadyToRemove'
+
+generated_sources += custom_target(
+    'xyz/openbmc_project/State/ReadyToRemove__cpp'.underscorify(),
+    input: [
+        '../../../../../yaml/xyz/openbmc_project/State/ReadyToRemove.interface.yaml',
+    ],
+    output: [
+        'common.hpp',
+        'server.hpp',
+        'server.cpp',
+        'aserver.hpp',
+        'client.hpp',
+    ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog,
+        '--command',
+        'cpp',
+        '--output',
+        meson.current_build_dir(),
+        '--tool',
+        sdbusplusplus_prog,
+        '--directory',
+        meson.current_source_dir() / '../../../../../yaml',
+        'xyz/openbmc_project/State/ReadyToRemove',
+    ],
+    install: should_generate_cpp,
+    install_dir: [
+        get_option('includedir') / sdbusplus_current_path,
+        get_option('includedir') / sdbusplus_current_path,
+        false,
+        get_option('includedir') / sdbusplus_current_path,
+        get_option('includedir') / sdbusplus_current_path,
+    ],
+    build_by_default: should_generate_cpp,
+)
+

--- a/gen/xyz/openbmc_project/State/meson.build
+++ b/gen/xyz/openbmc_project/State/meson.build
@@ -10,6 +10,7 @@ subdir('Host')
 subdir('Leak')
 subdir('OperatingSystem')
 subdir('PowerOnHours')
+subdir('ReadyToRemove')
 subdir('ScheduledHostTransition')
 subdir('Shutdown')
 subdir('SystemdTarget')
@@ -200,6 +201,30 @@ generated_markdown += custom_target(
         '--directory',
         meson.current_source_dir() / '../../../../yaml',
         'xyz/openbmc_project/State/PowerOnHours',
+    ],
+    install: should_generate_markdown,
+    install_dir: [inst_markdown_dir / sdbusplus_current_path],
+    build_by_default: should_generate_markdown,
+)
+
+generated_markdown += custom_target(
+    'xyz/openbmc_project/State/ReadyToRemove__markdown'.underscorify(),
+    input: [
+        '../../../../yaml/xyz/openbmc_project/State/ReadyToRemove.interface.yaml',
+    ],
+    output: ['ReadyToRemove.md'],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog,
+        '--command',
+        'markdown',
+        '--output',
+        meson.current_build_dir(),
+        '--tool',
+        sdbusplusplus_prog,
+        '--directory',
+        meson.current_source_dir() / '../../../../yaml',
+        'xyz/openbmc_project/State/ReadyToRemove',
     ],
     install: should_generate_markdown,
     install_dir: [inst_markdown_dir / sdbusplus_current_path],

--- a/yaml/xyz/openbmc_project/State/ReadyToRemove.interface.yaml
+++ b/yaml/xyz/openbmc_project/State/ReadyToRemove.interface.yaml
@@ -1,0 +1,30 @@
+description: >
+    Implement to indicate whether the item is prepared by the system for
+    removal. Setting the value to true shall cause the service to perform
+    appropriate actions to quiesce the item. Applications monitor this property
+    and perform appropriate actions. After successful removal, the inventory
+    item should be deleted or the Present property should be set to
+    false.  Setting ReadyToRemove=false cancels the removal preparation. If
+    quiesce fails, property remains at previous value. Errors are communicated
+    via D-Bus error responses. Applications should implement timeout and retry
+    logic.
+properties:
+    - name: ReadyToRemove
+      type: boolean
+      default: false
+      description: >
+          Indicates whether the item is prepared by the system for removal. true
+          - Item has been quiesced and is safe to remove. false - Item is in
+          active use and should not be removed.
+      errors:
+          - xyz.openbmc_project.Common.Error.NotAllowed
+associations:
+    - name: removable
+      description: >
+          Objects that implement ReadyToRemove can implement the "removable"
+          association to provide a link to an item to be removed.
+      reverse_name: removing
+      required_endpoint_interfaces:
+          - xyz.openbmc_project.Inventory.Item
+paths:
+    - namespace: /xyz/openbmc_project/state


### PR DESCRIPTION
This new D-Bus interface is implemented to indicate whether the item is prepared by the system for removal. Setting the value to true shall cause the service to perform appropriate actions to quiesce the item. Applications monitor this property and perform appropriate actions. After successful removal, the item should be deleted or the Present property should be set to false.
Setting ReadyToRemove to false cancels the removal preparation.

If quiesce fails, property remains at previous value. Errors are communicated via D-Bus error responses. Applications should implement timeout and retry logic.

ReadyToRemove is already on the Redfish Drive and PCIeDevice resource. ReadyToRemove was added to Redfish Manager, Redfish Assembly, and Redfish Chassis in 2025.3. [1]

An Example
```
"ReadyToRemove": {
                    "description": "An indication of whether the manager is prepared by the system for removal.",
                    "longDescription": "This property shall indicate whether the manager is ready for removal.  Setting the value to `true` shall cause the service to perform appropriate actions to quiesce the device.  A task may spawn while the device is quiescing.",
                    "readonly": false,
                    "type": [
                        "boolean",
                        "null"
                    ],
                    "versionAdded": "v1_23_0"
                },

https://redfish.dmtf.org/schemas/v1/Manager.v1_25_0.json
```

IBM plans to use ReadyToRemove for redundant BMCs. This ReadyToRemove is part of IBM's Concurrent maintenance

Change-Id: I5c50f8792d968e3427e64ebf99a2fc5f32aaa87a