### PR TITLE
com.ibm: Add SBEDumpTriggerType and DumpFilesPath to SBE dump interfaces

### DIFF
--- a/yaml/com/ibm/Dump/Create.interface.yaml
+++ b/yaml/com/ibm/Dump/Create.interface.yaml
@@ -33,6 +33,28 @@ enumerations:
                 The absolute path to a targeted Access Control File (ACF) used
                 to trigger a specific host operation like resource dump. The
                 file is parsed by the BMC and sent to the host via PLDM.
+          - name: "SBEDumpTriggerType"
+            description: >
+                Trigger type indicating the reason for SBE dump collection.
+          - name: "DumpFilesPath"
+            description: >
+                Path to the collected dump files, currently used by SBE dump creation.
+
+    - name: SBEDumpTriggerType
+      description: >
+          Trigger type indicating the reason for SBE dump collection.
+      values:
+          - name: "Timeout"
+            description: >
+                SBE dump collected due to an SBE timeout, where the SBE became
+                unresponsive within the expected time.
+          - name: "BootFailure"
+            description: >
+                SBE dump collected due to a boot failure encountered by the SBE
+                during the SBE boot phase.
+          - name: "Downstream"
+            description: >
+                SBE dump requested for a chip-internal downstream SBE.
 
     - name: DumpType
       description: >

--- a/yaml/com/ibm/Dump/Entry/SBE.interface.yaml
+++ b/yaml/com/ibm/Dump/Entry/SBE.interface.yaml
@@ -26,3 +26,15 @@ properties:
           A unique id of the failing SBE which is causing the dump. This ID
           could be used to identify the specific SBE  within the system. The
           value should be a 32-bit unsigned integer.
+
+    - name: SBEDumpTriggerType
+      type: enum[com.ibm.Dump.Create.SBEDumpTriggerType]
+      description: >
+          The type of the SBE dump indicating the condition that triggered the
+          dump collection. Possible values are Timeout, BootFailure, and
+          Downstream.
+
+    - name: DumpFilesPath
+      type: string
+      description: >
+          Path to the collected dump files, currently used by SBE dump creation.


### PR DESCRIPTION
com.ibm: Add SBEDumpTriggerType and DumpFilesPath to SBE dump intf
Add a new SBEDumpTriggerType enumeration to com.ibm.Dump.Create
with three values representing the conditions that can trigger
an SBE dump collection:
  - Timeout: SBE became unresponsive within the expected time
  - BootFailure: SBE encountered a failure during the SBE boot phase
  - Downstream: SBE dump requested for a chip-internal downstream SBE

Also add SBEDumpTriggerType and DumpFilesPath as new CreateParameters
entries in Create.interface.yaml so callers can pass these when
requesting an SBE dump.

In Entry/SBE.interface.yaml, add corresponding properties:
  - SBEDumpTriggerType(enum[com.ibm.Dump.Create.SBEDumpTriggerType])
     to record the trigger condition of the collected dump
  - DumpFilesPath(string): path to the collected dump files,
     currently used by SBE dump creation