### PR TITLE
Add GetParsedVPDData API to Manager interface

### DIFF
--- a/yaml/com/ibm/VPD/Manager.interface.yaml
+++ b/yaml/com/ibm/VPD/Manager.interface.yaml
@@ -264,6 +264,26 @@ methods:
                 been successfully initiated. It doesn't indicate VPD collection
                 status of the system.
 
+    - name: GetParsedVPD
+      description: >
+          Method to get the parsed VPD for a given FRU.
+      parameters:
+          - name: fruPath
+            type: string
+            description: >
+                FRU path (EEPROM path) of the FRU whose parsed VPD is requested.
+      returns:
+          - name: parsedVPDData
+            type: >
+                variant[dict[string,dict[string,array[byte]]],
+                dict[string,variant[array[byte],string,uint64]]]
+            description: >
+                Parsed VPD in the format of dictionary of <record, <keyword, value>>
+                or <keyword, value>.
+      errors:
+          - xyz.openbmc_project.Common.Error.InvalidArgument
+          - xyz.openbmc_project.Common.Device.Error.ReadFailure
+
 properties:
     - name: CollectionStatus
       type: enum[self.Status]


### PR DESCRIPTION
Add new D-Bus method GetParsedVPD to com.ibm.VPD.Manager interface that returns the fully parsed VPD for a given FRU (EEPROM) path.

The method accepts a fruPath(EEPROM path) as input and returns a map of record names to keyword-value pairs, where each value can be:
- an array[byte] if IPZ VPD.
- a variant of array[byte], string, or uint64_t if Keyword/Dimm type.

UseCase:
VPD-tool will consume the output of this new API and will dump the VPD for the given FRU path.

Change-Id: Ic6cd3e270aa8da9f8918c8be1d08a6261b2db63d