### PR TITLE
openpower: Add PELID logging interface

### DIFF
--- a/gen/org/open_power/Logging/PEL/PELID/meson.build
+++ b/gen/org/open_power/Logging/PEL/PELID/meson.build
@@ -1,0 +1,40 @@
+# Generated file; do not modify.
+
+sdbusplus_current_path = 'org/open_power/Logging/PEL/PELID'
+
+generated_sources += custom_target(
+    'org/open_power/Logging/PEL/PELID__cpp'.underscorify(),
+    input: [
+        '../../../../../../yaml/org/open_power/Logging/PEL/PELID.interface.yaml',
+    ],
+    output: [
+        'common.hpp',
+        'server.hpp',
+        'server.cpp',
+        'aserver.hpp',
+        'client.hpp',
+    ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog,
+        '--command',
+        'cpp',
+        '--output',
+        meson.current_build_dir(),
+        '--tool',
+        sdbusplusplus_prog,
+        '--directory',
+        meson.current_source_dir() / '../../../../../../yaml',
+        'org/open_power/Logging/PEL/PELID',
+    ],
+    install: should_generate_cpp,
+    install_dir: [
+        get_option('includedir') / sdbusplus_current_path,
+        get_option('includedir') / sdbusplus_current_path,
+        false,
+        get_option('includedir') / sdbusplus_current_path,
+        get_option('includedir') / sdbusplus_current_path,
+    ],
+    build_by_default: should_generate_cpp,
+)
+

--- a/gen/org/open_power/Logging/PEL/meson.build
+++ b/gen/org/open_power/Logging/PEL/meson.build
@@ -1,5 +1,6 @@
 # Generated file; do not modify.
 subdir('Entry')
+subdir('PELID')
 
 sdbusplus_current_path = 'org/open_power/Logging/PEL'
 
@@ -55,6 +56,30 @@ generated_markdown += custom_target(
         '--directory',
         meson.current_source_dir() / '../../../../../yaml',
         'org/open_power/Logging/PEL/Entry',
+    ],
+    install: should_generate_markdown,
+    install_dir: [inst_markdown_dir / sdbusplus_current_path],
+    build_by_default: should_generate_markdown,
+)
+
+generated_markdown += custom_target(
+    'org/open_power/Logging/PEL/PELID__markdown'.underscorify(),
+    input: [
+        '../../../../../yaml/org/open_power/Logging/PEL/PELID.interface.yaml',
+    ],
+    output: ['PELID.md'],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog,
+        '--command',
+        'markdown',
+        '--output',
+        meson.current_build_dir(),
+        '--tool',
+        sdbusplusplus_prog,
+        '--directory',
+        meson.current_source_dir() / '../../../../../yaml',
+        'org/open_power/Logging/PEL/PELID',
     ],
     install: should_generate_markdown,
     install_dir: [inst_markdown_dir / sdbusplus_current_path],

--- a/yaml/org/open_power/Logging/PEL/PELID.interface.yaml
+++ b/yaml/org/open_power/Logging/PEL/PELID.interface.yaml
@@ -1,0 +1,18 @@
+description: >
+    Implement this interface on objects that retain an OpenPOWER Platform Event
+    Log (PEL) identifier. The identifier is copied metadata and does not require
+    the corresponding PEL D-Bus object to remain present.
+
+properties:
+    - name: PELID
+      type: uint32
+      default: 0
+      flags:
+          - readonly
+      description: >
+          The 32-bit Entry ID (EID) of the Platform Event Log related to this
+          object. This is the PEL ID, not the OpenBMC logging entry ID or the
+          PEL Platform Log ID (PLID). The value remains as recorded metadata
+          even if the PEL is offloaded or purged; it does not guarantee that a
+          corresponding PEL D-Bus object exists. A value of zero indicates that
+          no PEL ID is available.


### PR DESCRIPTION
Add an OpenPOWER PEL decorator interface that retains the 32-bit PEL Entry ID associated with another D-Bus object. This lets a system dump entry keep correlation metadata after its PEL is offloaded or purged.

Make the property read-only and use zero when no PEL ID is available. Add generated C++ and Markdown Meson targets.

Change-Id: Ic3704e694600dfa74d392e324263a9e23f1e9dc9