### PR TITLE
com.ibm: Fix CI formatting

### DIFF
--- a/yaml/com/ibm/VPD/Manager.interface.yaml
+++ b/yaml/com/ibm/VPD/Manager.interface.yaml
@@ -278,8 +278,8 @@ methods:
                 variant[dict[string,dict[string,array[byte]]],
                 dict[string,variant[array[byte],string,uint64]]]
             description: >
-                Parsed VPD in the format of dictionary of <record, <keyword, value>>
-                or <keyword, value>.
+                Parsed VPD in the format of dictionary of <record, <keyword,
+                value>> or <keyword, value>.
       errors:
           - xyz.openbmc_project.Common.Error.InvalidArgument
           - xyz.openbmc_project.Common.Device.Error.ReadFailure


### PR DESCRIPTION
A recent change went in, causing CI failure, due to formatting failure.

Change-Id: I3a7932f4cbdfbd3d332c1f1eb6b0fe9f01f9e262